### PR TITLE
Fix for parameters and placeholders in whereInQuery in Paginator

### DIFF
--- a/lib/DoctrineExtensions/Paginate/Paginate.php
+++ b/lib/DoctrineExtensions/Paginate/Paginate.php
@@ -91,7 +91,7 @@ class Paginate
      */
     static public function createWhereInQuery(Query $query, array $ids, $namespace = 'pgid')
     {
-        $whereInQuery = clone $query;
+		$whereInQuery = self::cloneQuery($query);
         $whereInQuery->setHint(Query::HINT_CUSTOM_TREE_WALKERS, array('DoctrineExtensions\Paginate\WhereInWalker'));
         $whereInQuery->setHint('id.count', count($ids));
         $whereInQuery->setHint('pg.ns', $namespace);

--- a/lib/DoctrineExtensions/Paginate/WhereInWalker.php
+++ b/lib/DoctrineExtensions/Paginate/WhereInWalker.php
@@ -85,13 +85,24 @@ class WhereInWalker extends TreeWalkerAdapter
 
         $conditionalPrimary = new ConditionalPrimary;
         $conditionalPrimary->simpleConditionalExpression = $expression;
-
-        $AST->whereClause = new WhereClause(
-            new ConditionalExpression(array(
+        if(
+            $AST->whereClause instanceof WhereClause
+            && $AST->whereClause->conditionalExpression
+        ) {
+            $AST->whereClause = new WhereClause(
                 new ConditionalTerm(array(
-                    new ConditionalFactor($conditionalPrimary)
+                    new ConditionalFactor($conditionalPrimary),
+                    $AST->whereClause->conditionalExpression
                 ))
-            ))
-        );
+            );
+        } else {
+            $AST->whereClause = new WhereClause(
+                new ConditionalExpression(array(
+                    new ConditionalTerm(array(
+                        new ConditionalFactor($conditionalPrimary)
+                    ))
+                ))
+            );
+        }
     }
 }


### PR DESCRIPTION
\DoctrineExtensions\Paginate\Paginate.php: The issue in this case was related to the fact that cloning a query does not bring the parameters I've set in the cloned one (as of __clone in the query object). This is a trouble if I have some placeholders that need to be filled, like in my case.

\DoctrineExtensions\Paginate\WhereInWalker.php: this is probably not the best way of solving my issue, and I'm probably wrong as it could be related to my first fix, but the problem here is that the AST walker completely replaces the where clause, while I want it to add clauses to enforce my ids to be within the paginator page range. Please notice that I've just learned a bit about AST, so please tell me if possible if I'm doing things the wrong way.
