### PR TITLE
Forward compatibility with PHPUnit 3.6.0

### DIFF
--- a/lib/DoctrineExtensions/PHPUnit/DoctrineMetadata.php
+++ b/lib/DoctrineExtensions/PHPUnit/DoctrineMetadata.php
@@ -140,4 +140,25 @@ class DoctrineMetadata implements \PHPUnit_Extensions_Database_DB_IMetaData
     {
         return false;
     }
+
+    /**
+     * Disables primary keys if the rdbms does not allow setting them otherwise
+     *
+     * @param string $tableName
+     */
+    public function disablePrimaryKeys($tableName)
+    {
+        return;
+    }
+
+    /**
+     * Reenables primary keys after they have been disabled
+     *
+     * @param string $tableName
+     */
+    public function enablePrimaryKeys($tableName)
+    {
+        return;
+    }
+
 }

--- a/lib/DoctrineExtensions/PHPUnit/TestConnection.php
+++ b/lib/DoctrineExtensions/PHPUnit/TestConnection.php
@@ -147,4 +147,25 @@ class TestConnection implements \PHPUnit_Extensions_Database_DB_IDatabaseConnect
     {
         return false;
     }
+
+    /**
+     * Disables primary keys if connection does not allow setting them otherwise
+     *
+     * @param string $tableName
+     */
+    public function disablePrimaryKeys($tableName)
+    {
+        $this->getMetaData()->disablePrimaryKeys($tableName);
+    }
+
+    /**
+     * Reenables primary keys after they have been disabled
+     *
+     * @param string $tableName
+     */
+    public function enablePrimaryKeys($tableName)
+    {
+        $this->getMetaData()->enablePrimaryKeys($tableName);
+    }
+
 }


### PR DESCRIPTION
Hi, I've installed PHPUnit 3.6.0RC1 and it declares these new methods in <code>PHPUnit_Extensions_Database_DB_IDatabaseConnection</code>, so I've copy&pasted them from default implementation and it works just fine.
