### PR TITLE
Fixed bug on paginating ORDER BY queries

### DIFF
--- a/lib/DoctrineExtensions/Paginate/LimitSubqueryWalker.php
+++ b/lib/DoctrineExtensions/Paginate/LimitSubqueryWalker.php
@@ -20,7 +20,7 @@ namespace DoctrineExtensions\Paginate;
 
 use Doctrine\ORM\Query\TreeWalkerAdapter,
     Doctrine\ORM\Query\AST\SelectStatement,
-    Doctrine\ORM\Query\AST\SimpleSelectExpression,
+    Doctrine\ORM\Query\AST\SelectExpression,
     Doctrine\ORM\Query\AST\PathExpression,
     Doctrine\ORM\Query\AST\AggregateExpression;
 
@@ -35,6 +35,10 @@ use Doctrine\ORM\Query\TreeWalkerAdapter,
  */
 class LimitSubqueryWalker extends TreeWalkerAdapter
 {
+    /**
+     * @var int Counter for generating unique order column aliases
+     */
+    private $_aliasCounter = 0;
 
     /**
      * Walks down a SelectStatement AST node, modifying it to retrieve DISTINCT ids
@@ -68,7 +72,7 @@ class LimitSubqueryWalker extends TreeWalkerAdapter
         $pathExpression->type = PathExpression::TYPE_STATE_FIELD;
 
         $AST->selectClause->selectExpressions = array(
-            new SimpleSelectExpression($pathExpression)
+            new SelectExpression($pathExpression, '_dctrn_id')
         );
 
         if (isset($AST->orderByClause)) {
@@ -79,7 +83,7 @@ class LimitSubqueryWalker extends TreeWalkerAdapter
                                 $item->expression->field
                 );
                 $pathExpression->type = PathExpression::TYPE_STATE_FIELD;
-                $AST->selectClause->selectExpressions[] = new SimpleSelectExpression($pathExpression);
+                $AST->selectClause->selectExpressions[] = new SelectExpression($pathExpression, '_dctrn_ord' . $this->_aliasCounter++);
             }
         }
 


### PR DESCRIPTION
In some cases, the paginator can give the wrong result or fail when an explicit
ORDER BY clause collides with the field that Paginate is trying to
select in order to limit the query.

Example: User belongsTo group, where group 1 has 4 users. Both User and Group have an id
field. The following DQL will, when paginated, return only a single user and not all 4 users.

SELECT u FROM User u LEFT JOIN u.group g WHERE g.name = 'Some group' ORDER BY g.id ASC

Paginate will issue a select for the User.id but adds the ORDER BY
clause in the result set. But the ScalarHydrator simply overwrites the
User.id with the Group.id, causing the query to fail (or, in the case of
accidentally matching IDs, simply return a single result).

This update ensures that the LimitSubQuery uses unique column aliases to
fix the issue.
