### PR TITLE
Add support for paginating WHERE NOT ... queries

### DIFF
--- a/lib/DoctrineExtensions/Paginate/WhereInWalker.php
+++ b/lib/DoctrineExtensions/Paginate/WhereInWalker.php
@@ -110,8 +110,10 @@ class WhereInWalker extends TreeWalkerAdapter
                                 )
                 );
             }
-            // an OR clause
-            elseif ($AST->whereClause->conditionalExpression instanceof ConditionalExpression) {
+            // an OR or NOT clause
+            elseif ($AST->whereClause->conditionalExpression instanceof ConditionalExpression
+                || $AST->whereClause->conditionalExpression instanceof ConditionalFactor
+            ) {
                 $tmpPrimary = new ConditionalPrimary;
                 $tmpPrimary->conditionalExpression = $AST->whereClause->conditionalExpression;
                 $AST->whereClause->conditionalExpression = new ConditionalTerm(


### PR DESCRIPTION
The Paginate DoctrineExtension throws an exception on a DQL query like:

SELECT u FROM User u WHERE NOT (u INSTANCE OF Person)

This is because Paginate does not know about the Doctrine\ORM\Query\AST\ConditionalFactor which implements the NOT operator. This patch adds support for that.
