### PR TITLE
Paginate order by mixed

### DIFF
--- a/lib/DoctrineExtensions/Paginate/LimitSubqueryWalker.php
+++ b/lib/DoctrineExtensions/Paginate/LimitSubqueryWalker.php
@@ -51,17 +51,19 @@ class LimitSubqueryWalker extends TreeWalkerAdapter
     {
         $parent = null;
         $parentName = null;
-        foreach ($this->_getQueryComponents() AS $dqlAlias => $qComp) {
+        $selectExpressions = array();
 
-            // skip mixed data in query
+        foreach ($this->_getQueryComponents() AS $dqlAlias => $qComp) {
+            // preserve mixed data in query for ordering
             if (isset($qComp['resultVariable'])) {
+                $selectExpressions[] = new SelectExpression($qComp['resultVariable'], $dqlAlias);
                 continue;
             }
 
             if ($qComp['parent'] === null && $qComp['nestingLevel'] == 0) {
                 $parent = $qComp;
                 $parentName = $dqlAlias;
-                break;
+                continue;
             }
         }
 
@@ -71,19 +73,20 @@ class LimitSubqueryWalker extends TreeWalkerAdapter
         );
         $pathExpression->type = PathExpression::TYPE_STATE_FIELD;
 
-        $AST->selectClause->selectExpressions = array(
-            new SelectExpression($pathExpression, '_dctrn_id')
-        );
+        array_unshift($selectExpressions, new SelectExpression($pathExpression, '_dctrn_id'));
+        $AST->selectClause->selectExpressions = $selectExpressions;
 
         if (isset($AST->orderByClause)) {
             foreach ($AST->orderByClause->orderByItems as $item) {
-                $pathExpression = new PathExpression(
-                                PathExpression::TYPE_STATE_FIELD | PathExpression::TYPE_SINGLE_VALUED_ASSOCIATION,
-                                $item->expression->identificationVariable,
-                                $item->expression->field
-                );
-                $pathExpression->type = PathExpression::TYPE_STATE_FIELD;
-                $AST->selectClause->selectExpressions[] = new SelectExpression($pathExpression, '_dctrn_ord' . $this->_aliasCounter++);
+                if ($item->expression instanceof PathExpression) {
+                    $pathExpression = new PathExpression(
+                                    PathExpression::TYPE_STATE_FIELD | PathExpression::TYPE_SINGLE_VALUED_ASSOCIATION,
+                                    $item->expression->identificationVariable,
+                                    $item->expression->field
+                    );
+                    $pathExpression->type = PathExpression::TYPE_STATE_FIELD;
+                    $AST->selectClause->selectExpressions[] = new SelectExpression($pathExpression, '_dctrn_ord' . $this->_aliasCounter++);
+                }
             }
         }
 


### PR DESCRIPTION
This change makes the Paginate extension work on queries that use ORDER
BY to order the results in a mixed resultset, such as for example:

SELECT g, COUNT(u.id) AS numUsers FROM GROUP g LEFT JOIN g.users u GROUP BY g.id ORDER BY numUsers DESC
