### PR TITLE
Activate cascading when truncating during setup

### DIFF
--- a/lib/DoctrineExtensions/PHPUnit/DatabaseTestCase.php
+++ b/lib/DoctrineExtensions/PHPUnit/DatabaseTestCase.php
@@ -48,8 +48,11 @@ abstract class DatabaseTestCase extends \PHPUnit_Extensions_Database_TestCase
      */
     protected function getSetUpOperation()
     {
+        $truncate_operation = new Truncate();
+        $truncate_operation->setCascade();
+
         return new \PHPUnit_Extensions_Database_Operation_Composite(array(
-            new Truncate(),
+            $truncate_operation,
             new \PHPUnit_Extensions_Database_Operation_Insert()
         ));
     }


### PR DESCRIPTION
We're using Doctrine with PostgreSQL and foreign keys. This leads to PDO exceptions if the `DatabaseTestCase` trys to truncate such tables.