### PR TITLE
Added SQL_CALC_FOUND_ROWS to MysqlWalker

### DIFF
--- a/src/Query/MysqlWalker.php
+++ b/src/Query/MysqlWalker.php
@@ -15,19 +15,19 @@ class MysqlWalker extends SqlWalker
     public function walkSelectClause($selectClause)
     {
         $sql = parent::walkSelectClause($selectClause);
-		
-		// Gets the query
-		$query = $this->getQuery();
-		
-		if ($query->getHint('mysqlWalker.sqlCalcFoundRows') === true) {
-			// Appends the SQL_CALC_FOUND_ROWS modifier
-			$sql = str_replace('SELECT', 'SELECT SQL_CALC_FOUND_ROWS', $sql);
-		}
 
-		if ($query->getHint('mysqlWalker.sqlNoCache') === true) {
-			// Appends the SQL_NO_CACHE modifier
-			$sql = str_replace('SELECT', 'SELECT SQL_NO_CACHE', $sql);
-		}
+        // Gets the query
+        $query = $this->getQuery();
+
+        if ($query->getHint('mysqlWalker.sqlCalcFoundRows') === true) {
+            // Appends the SQL_CALC_FOUND_ROWS modifier
+            $sql = str_replace('SELECT', 'SELECT SQL_CALC_FOUND_ROWS', $sql);
+        }
+
+        if ($query->getHint('mysqlWalker.sqlNoCache') === true) {
+            // Appends the SQL_NO_CACHE modifier
+            $sql = str_replace('SELECT', 'SELECT SQL_NO_CACHE', $sql);
+        }
 
         return $sql;
     }

--- a/src/Query/MysqlWalker.php
+++ b/src/Query/MysqlWalker.php
@@ -15,14 +15,19 @@ class MysqlWalker extends SqlWalker
     public function walkSelectClause($selectClause)
     {
         $sql = parent::walkSelectClause($selectClause);
+		
+		// Gets the query
+		$query = $this->getQuery();
+		
+		if ($query->getHint('mysqlWalker.sqlCalcFoundRows') === true) {
+			// Appends the SQL_CALC_FOUND_ROWS modifier
+			$sql = str_replace('SELECT', 'SELECT SQL_CALC_FOUND_ROWS', $sql);
+		}
 
-        if ($this->getQuery()->getHint('mysqlWalker.sqlNoCache') === true) {
-            if ($selectClause->isDistinct) {
-                $sql = str_replace('SELECT DISTINCT', 'SELECT DISTINCT SQL_NO_CACHE', $sql);
-            } else {
-                $sql = str_replace('SELECT', 'SELECT SQL_NO_CACHE', $sql);
-            }
-        }
+		if ($query->getHint('mysqlWalker.sqlNoCache') === true) {
+			// Appends the SQL_NO_CACHE modifier
+			$sql = str_replace('SELECT', 'SELECT SQL_NO_CACHE', $sql);
+		}
 
         return $sql;
     }


### PR DESCRIPTION
I added a functionality to MysqlWalker to allow the use of the SQL_CALC_FOUND_ROWS modifier in SELECT statements. It checks whether the hint mysqlWalker.sqlCalcFoundRows is set.

I also removed the isDistinct check. Correct me if I'm wrong, but I think it's unnecessary.

When the three modifiers are set, the resulting SELECT statement is as follows:
"SELECT SQL_NO_CACHE SQL_CALC_FOUND_ROWS DISTINCT ..."