### PR TITLE
Fix #165: Fix for using StringExpression in mysql GROUP_CONCAT function.

### DIFF
--- a/src/Query/Mysql/GroupConcat.php
+++ b/src/Query/Mysql/GroupConcat.php
@@ -26,7 +26,11 @@ class GroupConcat extends FunctionNode
 
         // first Path Expression is mandatory
         $this->pathExp = array();
-        $this->pathExp[] = $parser->SingleValuedPathExpression();
+        if ($lexer->isNextToken(Lexer::T_IDENTIFIER)) {
+            $this->pathExp[] = $parser->StringExpression();
+        } else {
+            $this->pathExp[] = $parser->SingleValuedPathExpression();
+        }
 
         while ($lexer->isNextToken(Lexer::T_COMMA)) {
             $parser->match(Lexer::T_COMMA);


### PR DESCRIPTION
Fix for using StringExpression in mysql GROUP_CONCAT function.