### PR TITLE
Missing SQL comment hint on all types

### DIFF
--- a/src/Types/CarbonDateTimeType.php
+++ b/src/Types/CarbonDateTimeType.php
@@ -25,4 +25,9 @@ class CarbonDateTimeType extends DateTimeType
 
         return $result;
     }
+
+    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    {
+        return true;
+    }
 }

--- a/src/Types/CarbonDateTimeTzType.php
+++ b/src/Types/CarbonDateTimeTzType.php
@@ -25,4 +25,9 @@ class CarbonDateTimeTzType extends DateTimeTzType
 
         return $result;
     }
+
+    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    {
+        return true;
+    }
 }

--- a/src/Types/CarbonDateType.php
+++ b/src/Types/CarbonDateType.php
@@ -25,4 +25,9 @@ class CarbonDateType extends DateType
 
         return $result;
     }
+
+    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    {
+        return true;
+    }
 }

--- a/src/Types/CarbonTimeType.php
+++ b/src/Types/CarbonTimeType.php
@@ -25,4 +25,9 @@ class CarbonTimeType extends TimeType
 
         return $result;
     }
+
+    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    {
+        return true;
+    }
 }

--- a/src/Types/ZendDateType.php
+++ b/src/Types/ZendDateType.php
@@ -52,4 +52,9 @@ class ZendDateType extends Type
         }
         return $val;
     }
+
+    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    {
+        return true;
+    }
 }

--- a/tests/Types/CarbonDateTest.php
+++ b/tests/Types/CarbonDateTest.php
@@ -3,10 +3,9 @@
 namespace DoctrineExtensions\Tests\Types;
 
 use Carbon\Carbon,
-    Doctrine\Common\EventManager,
-    Doctrine\ORM\EntityManager,
     Doctrine\ORM\Tools\SchemaTool,
-    DoctrineExtensions\Tests\Entities\CarbonDate as Entity;
+    DoctrineExtensions\Tests\Entities\CarbonDate as Entity,
+    Doctrine\DBAL\Types\Type;
 
 /**
  * Test type that maps an SQL DATETIME/TIMESTAMP to a Carbon/Carbon object.
@@ -19,10 +18,10 @@ class CarbonDateTest extends \PHPUnit_Framework_TestCase
 
     public static function setUpBeforeClass()
     {
-        \Doctrine\DBAL\Types\Type::addType('CarbonDate', 'DoctrineExtensions\Types\CarbonDateType');
-        \Doctrine\DBAL\Types\Type::addType('CarbonDateTime', 'DoctrineExtensions\Types\CarbonDateTimeType');
-        \Doctrine\DBAL\Types\Type::addType('CarbonDateTimeTz', 'DoctrineExtensions\Types\CarbonDateTimeTzType');
-        \Doctrine\DBAL\Types\Type::addType('CarbonTime', 'DoctrineExtensions\Types\CarbonTimeType');
+        Type::addType('CarbonDate', 'DoctrineExtensions\Types\CarbonDateType');
+        Type::addType('CarbonDateTime', 'DoctrineExtensions\Types\CarbonDateTimeType');
+        Type::addType('CarbonDateTimeTz', 'DoctrineExtensions\Types\CarbonDateTimeTzType');
+        Type::addType('CarbonTime', 'DoctrineExtensions\Types\CarbonTimeType');
     }
 
     public function setUp()
@@ -131,14 +130,24 @@ class CarbonDateTest extends \PHPUnit_Framework_TestCase
         $this->em->flush();
     }
 
-    public function testTypesThatMapToAlreadyMappedDatabaseTypesRequireCommentHint()
+    /**
+     * @dataProvider typeProvider
+     */
+    public function testTypesThatMapToAlreadyMappedDatabaseTypesRequireCommentHint($type)
     {
         /** @var \Doctrine\DBAL\Platforms\AbstractPlatform $platform */
         $platform = $this->getMockForAbstractClass('Doctrine\DBAL\Platforms\AbstractPlatform');
 
-        $this->assertTrue(\Doctrine\DBAL\Types\Type::getType('CarbonDate')->requiresSQLCommentHint($platform));
-        $this->assertTrue(\Doctrine\DBAL\Types\Type::getType('CarbonDateTime')->requiresSQLCommentHint($platform));
-        $this->assertTrue(\Doctrine\DBAL\Types\Type::getType('CarbonDateTimeTz')->requiresSQLCommentHint($platform));
-        $this->assertTrue(\Doctrine\DBAL\Types\Type::getType('CarbonTime')->requiresSQLCommentHint($platform));
+        $this->assertTrue(Type::getType($type)->requiresSQLCommentHint($platform));
+    }
+
+    public function typeProvider()
+    {
+        return array(
+            array('CarbonDate'),
+            array('CarbonDateTime'),
+            array('CarbonDateTimeTz'),
+            array('CarbonTime'),
+        );
     }
 }

--- a/tests/Types/CarbonDateTest.php
+++ b/tests/Types/CarbonDateTest.php
@@ -130,4 +130,15 @@ class CarbonDateTest extends \PHPUnit_Framework_TestCase
         $this->em->persist($entity);
         $this->em->flush();
     }
+
+    public function testTypesThatMapToAlreadyMappedDatabaseTypesRequireCommentHint()
+    {
+        /** @var \Doctrine\DBAL\Platforms\AbstractPlatform $platform */
+        $platform = $this->getMockForAbstractClass('Doctrine\DBAL\Platforms\AbstractPlatform');
+
+        $this->assertTrue(\Doctrine\DBAL\Types\Type::getType('CarbonDate')->requiresSQLCommentHint($platform));
+        $this->assertTrue(\Doctrine\DBAL\Types\Type::getType('CarbonDateTime')->requiresSQLCommentHint($platform));
+        $this->assertTrue(\Doctrine\DBAL\Types\Type::getType('CarbonDateTimeTz')->requiresSQLCommentHint($platform));
+        $this->assertTrue(\Doctrine\DBAL\Types\Type::getType('CarbonTime')->requiresSQLCommentHint($platform));
+    }
 }

--- a/tests/Types/ZendDateTest.php
+++ b/tests/Types/ZendDateTest.php
@@ -81,4 +81,12 @@ class ZendDateTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($entity->date instanceof \Zend_Date);
         $this->assertTrue($entity->date->equals($zendDate));
     }
+
+    public function testTypesThatMapToAlreadyMappedDatabaseTypesRequireCommentHint()
+    {
+        /** @var \Doctrine\DBAL\Platforms\AbstractPlatform $platform */
+        $platform = $this->getMockForAbstractClass('Doctrine\DBAL\Platforms\AbstractPlatform');
+
+        $this->assertTrue(\Doctrine\DBAL\Types\Type::getType('ZendDate')->requiresSQLCommentHint($platform));
+    }
 }


### PR DESCRIPTION
As all types extend Doctrine types, we need the comment hint so reverse engineering works.

Right now, the schema tool always suggests modifications to date columns defined with this types.