### PR TITLE
Add CONCAT_WS for Sqlite

### DIFF
--- a/config/sqlite.yml
+++ b/config/sqlite.yml
@@ -24,7 +24,7 @@ doctrine:
              string_functions:
 #                 binary: DoctrineExtensions\Query\Sqlite\Binary
 #                 char_length: DoctrineExtensions\Query\Sqlite\CharLength
-#                 concat_ws: DoctrineExtensions\Query\Sqlite\ConcatWs
+                 concat_ws: DoctrineExtensions\Query\Sqlite\ConcatWs
 #                 countif: DoctrineExtensions\Query\Sqlite\CountIf
 #                 crc32: DoctrineExtensions\Query\Sqlite\Crc32
 #                 degrees: DoctrineExtensions\Query\Sqlite\Degrees

--- a/src/Query/Sqlite/ConcatWs.php
+++ b/src/Query/Sqlite/ConcatWs.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace DoctrineExtensions\Query\Sqlite;
+
+use Doctrine\ORM\Query\AST\Functions\FunctionNode,
+    Doctrine\ORM\Query\Lexer;
+
+/**
+ * @author Bas de Ruiter <winkbrace@gmail.com>
+ */
+class ConcatWs extends FunctionNode
+{
+    private $values = array();
+    private $notEmpty = false;
+
+    public function parse(\Doctrine\ORM\Query\Parser $parser)
+    {
+        $parser->match(Lexer::T_IDENTIFIER);
+        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+
+        // Add the concat separator to the values array.
+        $this->values[] = $parser->ArithmeticExpression();
+
+        // Add the rest of the strings to the values array. CONCAT_WS must
+        // be used with at least 2 strings not including the separator.
+
+        $lexer = $parser->getLexer();
+
+        while (count($this->values) < 3 || $lexer->lookahead['type'] == Lexer::T_COMMA) {
+            $parser->match(Lexer::T_COMMA);
+            $peek = $lexer->glimpse();
+
+            $this->values[] = $peek['value'] == '('
+                ? $parser->FunctionDeclaration()
+                : $parser->ArithmeticExpression();
+        }
+
+        while ($lexer->lookahead['type'] == Lexer::T_IDENTIFIER) {
+            switch (strtolower($lexer->lookahead['value'])) {
+                case 'notempty':
+                    $parser->match(Lexer::T_IDENTIFIER);
+                    $this->notEmpty = true;
+                    break;
+
+                default: // Identifier not recognized (causes exception).
+                    $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+                    break;
+            }
+        }
+
+        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+    }
+
+    public function getSql(\Doctrine\ORM\Query\SqlWalker $sqlWalker)
+    {
+        $separator = array_shift($this->values)->simpleArithmeticExpression->value;
+
+        // Create an array to hold the query elements.
+        $queryBuilder = array('(');
+
+        // Iterate over the captured expressions and add them to the query.
+        for ($i = 0; $i < count($this->values); $i++) {
+            if ($i > 0) {
+                $queryBuilder[] = " || '$separator' || ";
+            }
+
+            // Dispatch the walker on the current node.
+            $queryBuilder[] = sprintf("IFNULL(%s, '')", $sqlWalker->walkArithmeticPrimary($this->values[$i]));
+        }
+
+        // Close the query.
+        $queryBuilder[] = ')';
+
+        // Return the joined query.
+        return implode('', $queryBuilder);
+    }
+}

--- a/src/Query/Sqlite/DateFormat.php
+++ b/src/Query/Sqlite/DateFormat.php
@@ -51,6 +51,11 @@ class DateFormat extends FunctionNode
      */
     private function convertFormat(ArithmeticExpression $expr)
     {
+        // when using bind variables there is no value component.
+        if (empty($expr->simpleArithmeticExpression->value)) {
+            return $expr;
+        }
+
         // The order of the array is important. %i converts to %M, but %M converts to %m, so %M has to be done first.
         $conversion = array(
             '%a' => '%w',       // Abbreviated weekday name (Sun..Sat)          -> day of week (0..6)

--- a/tests/Query/Sqlite/StringFunctionsTest.php
+++ b/tests/Query/Sqlite/StringFunctionsTest.php
@@ -21,4 +21,14 @@ class StringFunctionsTest extends SqliteTestCase
         $q = $this->entityManager->createQuery($dql);
         $this->assertEquals("SELECT REPLACE(b0_.id, '1', '2') AS {$this->columnAlias} FROM Blank b0_", $q->getSql());
     }
+
+    public function testConcatWs()
+    {
+        $dql = "SELECT CONCAT_WS('-', 'foo', 'bar', 'baz') as out FROM DoctrineExtensions\\Tests\\Entities\\Blank p";
+
+        $expected = "SELECT (IFNULL('foo', '') || '-' || IFNULL('bar', '') || '-' || IFNULL('baz', ''))"
+                . " AS {$this->columnAlias} FROM Blank b0_";
+
+        $this->assertEquals($expected, $this->entityManager->createQuery($dql)->getSql());
+    }
 }

--- a/tests/Query/SqliteTestCase.php
+++ b/tests/Query/SqliteTestCase.php
@@ -53,6 +53,7 @@ class SqliteTestCase extends \PHPUnit_Framework_TestCase
 
         $config->setCustomStringFunctions(
             array(
+                'CONCAT_WS' => 'DoctrineExtensions\Query\Sqlite\ConcatWs',
                 'IFNULL' => 'DoctrineExtensions\Query\Sqlite\IfNull',
                 'REPLACE' => 'DoctrineExtensions\Query\Sqlite\Replace',
             )


### PR DESCRIPTION
Add CONCAT_WS function for Sqlite.

This PR also contains a minor bugfix for Sqlite DATE_FORMAT when using bind variables instead of strings for the format.