### PR TITLE
Add mode parameter for YEARWEEK

### DIFF
--- a/src/Query/Mysql/YearWeek.php
+++ b/src/Query/Mysql/YearWeek.php
@@ -11,10 +11,17 @@ use Doctrine\ORM\Query\AST\Functions\FunctionNode,
 class YearWeek extends FunctionNode
 {
     public $date;
+    public $mode;
 
     public function getSql(\Doctrine\ORM\Query\SqlWalker $sqlWalker)
     {
-        return "YEARWEEK(" . $sqlWalker->walkArithmeticPrimary($this->date) . ")";
+        $sql = "YEARWEEK(" . $sqlWalker->walkArithmeticPrimary($this->date);
+        if ($this->mode != null) {
+            $sql .= ", " . $sqlWalker->walkLiteral($this->mode);
+        }
+        $sql .= ")";
+
+        return $sql;
     }
 
     public function parse(\Doctrine\ORM\Query\Parser $parser)
@@ -23,6 +30,11 @@ class YearWeek extends FunctionNode
         $parser->match(Lexer::T_OPEN_PARENTHESIS);
 
         $this->date = $parser->ArithmeticPrimary();
+
+        if (Lexer::T_COMMA === $parser->getLexer()->lookahead['type']) {
+            $parser->match(Lexer::T_COMMA);
+            $this->mode = $parser->Literal();
+        }
 
         $parser->match(Lexer::T_CLOSE_PARENTHESIS);
     }


### PR DESCRIPTION
While struggling with an ERP with weekly plannings, I noticed that MySQL's `YEARWEEK()` would not return the ISO value by default, but providing the second argument with value of 3 should match PHP DateTime's `'oW'` format.Unfortunately, this wasn't possible. Now it should be.