### PR TITLE
Fix using alias in DATE_ADD

### DIFF
--- a/src/Query/Mysql/DateAdd.php
+++ b/src/Query/Mysql/DateAdd.php
@@ -60,8 +60,8 @@ class DateAdd extends FunctionNode
         }
 
         return 'DATE_ADD(' .
-            $this->firstDateExpression->dispatch($sqlWalker) . ', INTERVAL ' .
-            $this->intervalExpression->dispatch($sqlWalker) . ' ' . $unit .
+            $sqlWalker->walkArithmeticTerm($this->firstDateExpression) . ', INTERVAL ' .
+            $sqlWalker->walkArithmeticTerm($this->intervalExpression) . ' ' . $unit .
         ')';
     }
 }

--- a/tests/Query/Mysql/DateTest.php
+++ b/tests/Query/Mysql/DateTest.php
@@ -2,6 +2,8 @@
 
 namespace DoctrineExtensions\Tests\Query\Mysql;
 
+use Doctrine\ORM\Version;
+
 class DateTest extends \DoctrineExtensions\Tests\Query\MysqlTestCase
 {
     public function testDateDiff()
@@ -24,6 +26,10 @@ class DateTest extends \DoctrineExtensions\Tests\Query\MysqlTestCase
 
     public function testDateAddWithColumnAlias()
     {
+        if(Version::VERSION < 2.2) {
+            $this->markTestSkipped('Alias is not supported in Doctrine 2.1 and lower');
+        }
+
         $dql = "SELECT p.created as alternative FROM DoctrineExtensions\Tests\Entities\Date p HAVING DATEADD(alternative, 4, 'MONTH') < 7";
         $q = $this->entityManager->createQuery($dql);
         $sql = "SELECT d0_.created AS created_0 FROM Date d0_ HAVING DATE_ADD(created_0, INTERVAL 4 MONTH) < 7";

--- a/tests/Query/Mysql/DateTest.php
+++ b/tests/Query/Mysql/DateTest.php
@@ -22,6 +22,15 @@ class DateTest extends \DoctrineExtensions\Tests\Query\MysqlTestCase
         $this->assertEquals($sql, $q->getSql());
     }
 
+    public function testDateAddWithColumnAlias()
+    {
+        $dql = "SELECT p.created as alternative FROM DoctrineExtensions\Tests\Entities\Date p HAVING DATEADD(alternative, 4, 'MONTH') < 7";
+        $q = $this->entityManager->createQuery($dql);
+        $sql = "SELECT d0_.created AS created_0 FROM Date d0_ HAVING DATE_ADD(created_0, INTERVAL 4 MONTH) < 7";
+
+        $this->assertEquals($sql, $q->getSql());
+    }
+
     public function testDateAddWithNegative()
     {
         $dql = "SELECT p FROM DoctrineExtensions\Tests\Entities\Date p WHERE DATEADD(CURRENT_TIME(), -4, 'MONTH') < 7";


### PR DESCRIPTION
Same changes as in pull #230 and issue #218 for DateDiff.

Tests will probably fail in Doctrine 2.2 like #239. 