### PR TITLE
Change ArithmeticPrimary to ArithmeticExpression for LEAST and GREATEST functions

### DIFF
--- a/src/Query/Mysql/Greatest.php
+++ b/src/Query/Mysql/Greatest.php
@@ -26,13 +26,13 @@ class Greatest extends FunctionNode
     {
         $parser->match(Lexer::T_IDENTIFIER);
         $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $this->field = $parser->ArithmeticPrimary();
+        $this->field = $parser->ArithmeticExpression();
         $lexer = $parser->getLexer();
 
         while (count($this->values) < 1 ||
             $lexer->lookahead['type'] != Lexer::T_CLOSE_PARENTHESIS) {
             $parser->match(Lexer::T_COMMA);
-            $this->values[] = $parser->ArithmeticPrimary();
+            $this->values[] = $parser->ArithmeticExpression();
         }
 
         $parser->match(Lexer::T_CLOSE_PARENTHESIS);

--- a/src/Query/Mysql/Least.php
+++ b/src/Query/Mysql/Least.php
@@ -25,13 +25,13 @@ class Least extends FunctionNode
     {
         $parser->match(Lexer::T_IDENTIFIER);
         $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $this->field = $parser->ArithmeticPrimary();
+        $this->field = $parser->ArithmeticExpression();
         $lexer = $parser->getLexer();
 
         while (count($this->values) < 1 ||
             $lexer->lookahead['type'] != Lexer::T_CLOSE_PARENTHESIS) {
             $parser->match(Lexer::T_COMMA);
-            $this->values[] = $parser->ArithmeticPrimary();
+            $this->values[] = $parser->ArithmeticExpression();
         }
 
         $parser->match(Lexer::T_CLOSE_PARENTHESIS);


### PR DESCRIPTION
As MySQL, the `GREATEST` and `LEAST` functions should accept `ArithmeticExpression`s and not be restricted to `ArithmeticPrimary`s