### PR TITLE
change - AesDecrypt and AesEncrypt classes, namespace updated to fix …

### DIFF
--- a/src/Query/Mysql/AesDecrypt.php
+++ b/src/Query/Mysql/AesDecrypt.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace BoaCompra\DoctrineExtensions\Query\Mysql;
+namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\Lexer;

--- a/src/Query/Mysql/AesEncrypt.php
+++ b/src/Query/Mysql/AesEncrypt.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace BoaCompra\DoctrineExtensions\Query\Mysql;
+namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\Lexer;


### PR DESCRIPTION
…#251

This change should fix the `The file was found but the class was not in it, the class name or namespace probably has a typo.` error user would get when trying to use the AesDecrypt and AesEncrypt extensions.