### PR TITLE
Fix SUBSTRING_INDEX for negative count

### DIFF
--- a/src/Query/Mysql/SubstringIndex.php
+++ b/src/Query/Mysql/SubstringIndex.php
@@ -29,7 +29,7 @@ class SubstringIndex extends FunctionNode
         $parser->match(Lexer::T_COMMA);
         $this->delimiter = $parser->ArithmeticPrimary();
         $parser->match(Lexer::T_COMMA);
-        $this->count = $parser->ArithmeticExpression();
+        $this->count = $parser->ArithmeticFactor();
         $parser->match(Lexer::T_CLOSE_PARENTHESIS);
     }
 


### PR DESCRIPTION
Edge case, but works of me.
`        ->andWhere("(SUBSTRING_INDEX(q.dates, ',', -1) = :date OR q.endDate = :date) ")`
throws Exception
`                                                                   
  [Doctrine\ORM\Query\QueryException]                               
  [Syntax Error] line 0, col 239: Error: Expected Literal, got '-'                                                                      
` 