### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require-dev": {
         "doctrine/orm": "~2.1",
         "nesbot/carbon": "*",
-        "phpunit/phpunit": "~4.5",
+        "phpunit/phpunit": "~4.8.35",
         "symfony/yaml": "~2.6",
         "zf1/zend-date": "~1.12",
         "zf1/zend-registry": "~1.12"

--- a/tests/Config/MysqlYamlTest.php
+++ b/tests/Config/MysqlYamlTest.php
@@ -2,12 +2,14 @@
 
 namespace DoctrineExtensions\Tests\Config;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Test that checks the README describes all of the query types
  *
  * @author Steve Lacey <steve@stevelacey.net>
  */
-class MysqlConfigTest extends \PHPUnit_Framework_TestCase
+class MysqlConfigTest extends TestCase
 {
     /** @var array */
     protected $functions;

--- a/tests/Query/DbTestCase.php
+++ b/tests/Query/DbTestCase.php
@@ -4,8 +4,9 @@ namespace DoctrineExtensions\tests\Query;
 use Doctrine\Common\Cache\ArrayCache;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
+use PHPUnit\Framework\TestCase;
 
-class DbTestCase extends \PHPUnit_Framework_TestCase
+class DbTestCase extends TestCase
 {
     /** @var EntityManager */
     public $entityManager;

--- a/tests/Types/CarbonDateTest.php
+++ b/tests/Types/CarbonDateTest.php
@@ -5,14 +5,15 @@ namespace DoctrineExtensions\Tests\Types;
 use Carbon\Carbon,
     Doctrine\ORM\Tools\SchemaTool,
     DoctrineExtensions\Tests\Entities\CarbonDate as Entity,
-    Doctrine\DBAL\Types\Type;
+    Doctrine\DBAL\Types\Type,
+    PHPUnit\Framework\TestCase;
 
 /**
  * Test type that maps an SQL DATETIME/TIMESTAMP to a Carbon/Carbon object.
  *
  * @author Steve Lacey <steve@stevelacey.net>
  */
-class CarbonDateTest extends \PHPUnit_Framework_TestCase
+class CarbonDateTest extends TestCase
 {
     public $entityManager = null;
 

--- a/tests/Types/ZendDateTest.php
+++ b/tests/Types/ZendDateTest.php
@@ -4,14 +4,15 @@ namespace DoctrineExtensions\Tests\Types;
 
 use Doctrine\Common\EventManager,
     Doctrine\ORM\EntityManager,
-    Doctrine\ORM\Tools\SchemaTool;
+    Doctrine\ORM\Tools\SchemaTool,
+    PHPUnit\Framework\TestCase;
 
 /**
  * Test type that maps an SQL DATETIME/TIMESTAMP to a Zend_Date object.
  *
  * @author Andreas Gallien <gallien@seleos.de>
  */
-class ZendDateTest extends \PHPUnit_Framework_TestCase
+class ZendDateTest extends TestCase
 {
     public $entityManager = null;
 


### PR DESCRIPTION
Use `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase`, while extending our TestCases. This will help us migrate to PHPUnit 6, [that no longer support this snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to update `PHPUnit` to [`^4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06), that supports this new namespace.