### PR TITLE
Drop support for PHP 5.3 and Doctrine < 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6
@@ -10,19 +9,11 @@ php:
   - 7.2
 
 env:
-  - DOCTRINE_VERSION=2.1.*
-  - DOCTRINE_VERSION=2.2.*
-  - DOCTRINE_VERSION=2.3.*
-  - DOCTRINE_VERSION=2.4.*
   - DOCTRINE_VERSION=2.5.*
   - DOCTRINE_VERSION=2.6.*
 
 matrix:
   exclude:
-  - php: 5.3
-    env: DOCTRINE_VERSION=2.5.*
-  - php: 5.3
-    env: DOCTRINE_VERSION=2.6.*
   - php: 5.4
     env: DOCTRINE_VERSION=2.6.*
   - php: 5.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,22 @@ env:
   - DOCTRINE_VERSION=2.3.*
   - DOCTRINE_VERSION=2.4.*
   - DOCTRINE_VERSION=2.5.*
+  - DOCTRINE_VERSION=2.6.*
 
 matrix:
   exclude:
   - php: 5.3
     env: DOCTRINE_VERSION=2.5.*
+  - php: 5.3
+    env: DOCTRINE_VERSION=2.6.*
+  - php: 5.4
+    env: DOCTRINE_VERSION=2.6.*
+  - php: 5.5
+    env: DOCTRINE_VERSION=2.6.*
+  - php: 5.6
+    env: DOCTRINE_VERSION=2.6.*
+  - php: 7
+    env: DOCTRINE_VERSION=2.6.*
 
 install:
   - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -9,10 +9,10 @@
         {"name": "Steve Lacey", "email": "steve@stevelacey.net"}
     ],
     "require": {
-        "php": ">=5.3.2"
+        "php": ">=5.4"
     },
     "require-dev": {
-        "doctrine/orm": "~2.1",
+        "doctrine/orm": "~2.5",
         "nesbot/carbon": "*",
         "phpunit/phpunit": "~4.5",
         "symfony/yaml": "~2.6",


### PR DESCRIPTION
- Requires a min of PHP 5.4 in Composer
- Requires a min of Doctrine 2.5 in Composer
- Stops testing for PHP 5.3
- Stops testing against Doctrine 2.1, 2.2, 2.3 and 2.4