### PR TITLE
Optional second parameter (fmt) for Oracle TRUNC function + test.

### DIFF
--- a/src/Query/Oracle/Trunc.php
+++ b/src/Query/Oracle/Trunc.php
@@ -30,12 +30,11 @@ class Trunc extends FunctionNode
                 $sqlWalker->walkArithmeticPrimary($this->fmt)
             );
         }
-        else {
-            return sprintf(
-                'TRUNC(%s)',
-                $sqlWalker->walkArithmeticPrimary($this->date)
-            );
-        }
+
+        return sprintf(
+            'TRUNC(%s)',
+            $sqlWalker->walkArithmeticPrimary($this->date)
+        );
     }
 
     public function parse(\Doctrine\ORM\Query\Parser $parser)

--- a/src/Query/Oracle/Trunc.php
+++ b/src/Query/Oracle/Trunc.php
@@ -3,6 +3,7 @@
 namespace DoctrineExtensions\Query\Oracle;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
+use Doctrine\ORM\Query\AST\Node;
 use Doctrine\ORM\Query\Lexer;
 
 /**
@@ -10,26 +11,46 @@ use Doctrine\ORM\Query\Lexer;
  */
 class Trunc extends FunctionNode
 {
+    /**
+     * @var Node
+     */
     private $date;
 
+    /**
+     * @var Node
+     */
     private $fmt;
 
     public function getSql(\Doctrine\ORM\Query\SqlWalker $sqlWalker)
     {
-        return sprintf(
+        if ($this->fmt) {
+            return sprintf(
                 'TRUNC(%s, %s)',
                 $sqlWalker->walkArithmeticPrimary($this->date),
                 $sqlWalker->walkArithmeticPrimary($this->fmt)
-        );
+            );
+        }
+        else {
+            return sprintf(
+                'TRUNC(%s)',
+                $sqlWalker->walkArithmeticPrimary($this->date)
+            );
+        }
     }
 
     public function parse(\Doctrine\ORM\Query\Parser $parser)
     {
+        $lexer = $parser->getLexer();
+
         $parser->match(Lexer::T_IDENTIFIER);
         $parser->match(Lexer::T_OPEN_PARENTHESIS);
         $this->date = $parser->ArithmeticExpression();
-        $parser->match(Lexer::T_COMMA);
-        $this->fmt = $parser->StringExpression();
+
+        if ($lexer->isNextToken(Lexer::T_COMMA)) {
+            $parser->match(Lexer::T_COMMA);
+            $this->fmt = $parser->StringExpression();
+        }
+
         $parser->match(Lexer::T_CLOSE_PARENTHESIS);
     }
 }

--- a/tests/Query/Oracle/TruncTest.php
+++ b/tests/Query/Oracle/TruncTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Query\Oracle;
+
+use DoctrineExtensions\Tests\Query\OracleTestCase;
+
+/**
+ * @author Alexey Kalinin <nitso@yandex.ru>
+ */
+class TruncTest extends OracleTestCase
+{
+    public function testFullQuery()
+    {
+        $dql = "SELECT TRUNC(d.created, 'YYYY') FROM DoctrineExtensions\Tests\Entities\Date d";
+        $q = $this->entityManager->createQuery($dql);
+
+        $sql = "SELECT TRUNC(d0_.created, 'YYYY') AS sclr_0 FROM Date d0_";
+        $this->assertEquals($sql, $q->getSql());
+    }
+
+    public function testShortQuery()
+    {
+        $dql = "SELECT TRUNC(d.created) FROM DoctrineExtensions\Tests\Entities\Date d";
+        $q = $this->entityManager->createQuery($dql);
+
+        $sql = "SELECT TRUNC(d0_.created) AS sclr_0 FROM Date d0_";
+        $this->assertEquals($sql, $q->getSql());
+    }
+}

--- a/tests/Query/Oracle/TruncTest.php
+++ b/tests/Query/Oracle/TruncTest.php
@@ -11,19 +11,19 @@ class TruncTest extends OracleTestCase
 {
     public function testFullQuery()
     {
-        $dql = "SELECT TRUNC(d.created, 'YYYY') FROM DoctrineExtensions\Tests\Entities\Date d";
+        $dql = 'SELECT TRUNC(d.created, \'YYYY\') FROM DoctrineExtensions\\Tests\\Entities\\Date d';
         $q = $this->entityManager->createQuery($dql);
 
-        $sql = "SELECT TRUNC(d0_.created, 'YYYY') AS sclr_0 FROM Date d0_";
+        $sql = 'SELECT TRUNC(d0_.created, \'YYYY\') AS sclr_0 FROM Date d0_';
         $this->assertEquals($sql, $q->getSql());
     }
 
     public function testShortQuery()
     {
-        $dql = "SELECT TRUNC(d.created) FROM DoctrineExtensions\Tests\Entities\Date d";
+        $dql = 'SELECT TRUNC(d.created) FROM DoctrineExtensions\\Tests\\Entities\\Date d';
         $q = $this->entityManager->createQuery($dql);
 
-        $sql = "SELECT TRUNC(d0_.created) AS sclr_0 FROM Date d0_";
+        $sql = 'SELECT TRUNC(d0_.created) AS sclr_0 FROM Date d0_';
         $this->assertEquals($sql, $q->getSql());
     }
 }


### PR DESCRIPTION
As of oracle specification for [date function](https://docs.oracle.com/cd/B19306_01/server.102/b14200/functions201.htm) and [numeric function](https://docs.oracle.com/cd/B19306_01/server.102/b14200/functions200.htm) second parameter for TRUNC function is optional. Both use similar syntax. 