### PR TITLE
Add SQLite Greatest and Least functions

### DIFF
--- a/config/sqlite.yml
+++ b/config/sqlite.yml
@@ -34,8 +34,10 @@ doctrine:
 #                 field: DoctrineExtensions\Query\Sqlite\Field
 #                 find_in_set: DoctrineExtensions\Query\Sqlite\FindInSet
 #                 group_concat: DoctrineExtensions\Query\Sqlite\GroupConcat
+                 greatest: DoctrineExtensions\Query\Sqlite\Greatest
                  ifelse: DoctrineExtensions\Query\Sqlite\IfElse
                  ifnull: DoctrineExtensions\Query\Sqlite\IfNull
+                 least: DoctrineExtensions\Query\Sqlite\Least
 #                 match: DoctrineExtensions\Query\Sqlite\MatchAgainst
 #                 md5: DoctrineExtensions\Query\Sqlite\Md5
 #                 nullif: DoctrineExtensions\Query\Sqlite\NullIf

--- a/src/Query/Sqlite/Greatest.php
+++ b/src/Query/Sqlite/Greatest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace DoctrineExtensions\Query\Sqlite;
+
+use Doctrine\ORM\Query\AST\Functions\FunctionNode;
+use Doctrine\ORM\Query\Lexer;
+use Doctrine\ORM\Query\Parser;
+use Doctrine\ORM\Query\SqlWalker;
+
+/**
+ * Class Greatest
+ * @package DoctrineExtensions\Query\Mysql
+ *
+ * @author Vas N <phpvas@gmail.com>
+ * @author Guven Atbakan <guven@atbakan.com>
+ */
+class Greatest extends FunctionNode
+{
+    private $field = null;
+
+    private $values = [];
+
+    /**
+     * @param Parser $parser
+     */
+    public function parse(Parser $parser)
+    {
+        $parser->match(Lexer::T_IDENTIFIER);
+        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $this->field = $parser->ArithmeticExpression();
+        $lexer = $parser->getLexer();
+
+        while (count($this->values) < 1 ||
+            $lexer->lookahead['type'] != Lexer::T_CLOSE_PARENTHESIS) {
+            $parser->match(Lexer::T_COMMA);
+            $this->values[] = $parser->ArithmeticExpression();
+        }
+
+        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+    }
+
+    /**
+     * @param SqlWalker $sqlWalker
+     * @return string
+     */
+    public function getSql(SqlWalker $sqlWalker)
+    {
+        $query = 'MAX(';
+
+        $query .= $this->field->dispatch($sqlWalker);
+
+        $query .= ', ';
+
+        for ($i = 0; $i < count($this->values); $i++) {
+            if ($i > 0) {
+                $query .= ', ';
+            }
+
+            $query .= $this->values[$i]->dispatch($sqlWalker);
+        }
+
+        $query .= ')';
+
+        return $query;
+    }
+}

--- a/src/Query/Sqlite/Least.php
+++ b/src/Query/Sqlite/Least.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace DoctrineExtensions\Query\Sqlite;
+
+use Doctrine\ORM\Query\AST\Functions\FunctionNode;
+use Doctrine\ORM\Query\Lexer;
+use Doctrine\ORM\Query\Parser;
+use Doctrine\ORM\Query\SqlWalker;
+
+/**
+ * Class Least
+ * @package DoctrineExtensions\Query\Mysql
+ *
+ * @author Vas N <phpvas@gmail.com>
+ */
+class Least extends FunctionNode
+{
+    private $field = null;
+
+    private $values = [];
+
+    /**
+     * @param Parser $parser
+     */
+    public function parse(Parser $parser)
+    {
+        $parser->match(Lexer::T_IDENTIFIER);
+        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $this->field = $parser->ArithmeticExpression();
+        $lexer = $parser->getLexer();
+
+        while (count($this->values) < 1 ||
+            $lexer->lookahead['type'] != Lexer::T_CLOSE_PARENTHESIS) {
+            $parser->match(Lexer::T_COMMA);
+            $this->values[] = $parser->ArithmeticExpression();
+        }
+
+        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+    }
+
+    /**
+     * @param SqlWalker $sqlWalker
+     * @return string
+     */
+    public function getSql(SqlWalker $sqlWalker)
+    {
+        $query = 'MIN(';
+
+        $query .= $this->field->dispatch($sqlWalker);
+
+        $query .= ', ';
+
+        for ($i = 0; $i < count($this->values); $i++) {
+            if ($i > 0) {
+                $query .= ', ';
+            }
+
+            $query .= $this->values[$i]->dispatch($sqlWalker);
+        }
+
+        $query .= ')';
+
+        return $query;
+    }
+}

--- a/tests/Query/Sqlite/GreatestTest.php
+++ b/tests/Query/Sqlite/GreatestTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace DoctrineExtensions\Tests\Query\Sqlite;
+
+use DoctrineExtensions\Tests\Query\SqliteTestCase;
+
+class GreatestTest extends SqliteTestCase
+{
+    public function testGreatest()
+    {
+        $this->assertDqlProducesSql(
+            "SELECT Greatest(2, 3) from DoctrineExtensions\Tests\Entities\Blank b",
+            'SELECT MAX(2, 3) AS sclr_0 FROM Blank b0_'
+        );
+    }
+}

--- a/tests/Query/Sqlite/LeastTest.php
+++ b/tests/Query/Sqlite/LeastTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace DoctrineExtensions\Tests\Query\Sqlite;
+
+use DoctrineExtensions\Tests\Query\SqliteTestCase;
+
+class LeastTest extends SqliteTestCase
+{
+    public function testLeast()
+    {
+        $this->assertDqlProducesSql(
+            "SELECT LEAST(2, 3) from DoctrineExtensions\Tests\Entities\Blank b",
+            'SELECT MIN(2, 3) AS sclr_0 FROM Blank b0_'
+        );
+    }
+}


### PR DESCRIPTION
We use SQLite for automated testing.
Problem is, that MySQL functions `greatest` and `least` have different names in SQLite, which are `max` and `min`.

I added SQLite functions to translate them for DQL.