### PR TITLE
Drop unsupported PHP versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,10 +9,10 @@
         {"name": "Steve Lacey", "email": "steve@stevelacey.net"}
     ],
     "require": {
-        "php": ">=5.4"
+        "php": "^7.1"
     },
     "require-dev": {
-        "doctrine/orm": "^2.5",
+        "doctrine/orm": "^2.6",
         "friendsofphp/php-cs-fixer": "^2.2.19",
         "nesbot/carbon": "*",
         "phpunit/phpunit": "^4.5",


### PR DESCRIPTION
Please note: this is not a complete PR, but a way to start a discussion (since issues are currently disabled).
If agreed, I can (of course) amend this PR and add all needed changes.

Rationale: Doctrine drop support for old version more than one year ago, see https://www.doctrine-project.org/2017/07/25/php-7.1-requirement-and-composer.html. So, we could/should release a new minor version that supports only latest Doctrine and current PHP versions (7.1/7.2/7.3)