### PR TITLE
Fix package casing deprecation issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To install this library, run the command below and you will get the latest
 version:
 
 ```
-composer require beberlei/DoctrineExtensions
+composer require beberlei/doctrineextensions
 ```
 
 If you want to run phpunit:


### PR DESCRIPTION
Deprecation warning: require.beberlei/DoctrineExtensions is invalid, it should not contain uppercase characters. Please use beberlei/doctrineextensions instead. Make sure you fix this as Composer 2.0 will error