### PR TITLE
Move doctrine/orm to require

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,10 +9,10 @@
         {"name": "Steve Lacey", "email": "steve@stevelacey.net"}
     ],
     "require": {
-        "php": "^7.1"
+        "php": "^7.1",
+        "doctrine/orm": "^2.6"
     },
     "require-dev": {
-        "doctrine/orm": "^2.6",
         "friendsofphp/php-cs-fixer": "^2.14",
         "nesbot/carbon": "*",
         "phpunit/phpunit": "^7.0 || ^8.0",


### PR DESCRIPTION
When requiring dependency as `composer require beberlei/doctrineextensions`, if you have `doctrine/orm` as direct dependency (in my case `"doctrine/orm": "~2.5"`), `"doctrine/orm": "^2.6"` [constraint](https://github.com/beberlei/DoctrineExtensions/pull/329/files#diff-b5d0ee8c97c7abd7e3fa29b9a27d1780L15) will not be taken into account since it's a dev dependency and `beberlei/doctrineextensions` will be installed alongside with incompatible version of `doctrine/orm`.