### PR TITLE
Add full "IN BOOLEAN MODE" and "WITH QUERY EXPANSION"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /composer.lock
 /tests/phpunit.xml
 /vendor
+/.idea

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 /composer.lock
 /tests/phpunit.xml
 /vendor
-/.idea

--- a/src/Query/Mysql/MatchAgainst.php
+++ b/src/Query/Mysql/MatchAgainst.php
@@ -50,10 +50,38 @@ class MatchAgainst extends FunctionNode
         if (strtolower($lexer->lookahead['value']) === 'boolean') {
             $parser->match(Lexer::T_IDENTIFIER);
             $this->booleanMode = true;
+        } elseif (strtolower($lexer->lookahead['value']) === 'in') {
+            $parser->match(Lexer::T_IDENTIFIER);
+
+            if (strtolower($lexer->lookahead['value']) !== 'boolean') {
+                $parser->syntaxError('boolean');
+            }
+            $parser->match(Lexer::T_IDENTIFIER);
+
+            if (strtolower($lexer->lookahead['value']) !== 'mode') {
+                $parser->syntaxError('mode');
+            }
+            $parser->match(Lexer::T_IDENTIFIER);
+
+            $this->booleanMode = true;
         }
 
         if (strtolower($lexer->lookahead['value']) === 'expand') {
             $parser->match(Lexer::T_IDENTIFIER);
+            $this->queryExpansion = true;
+        } elseif (strtolower($lexer->lookahead['value']) === 'with') {
+            $parser->match(Lexer::T_IDENTIFIER);
+
+            if (strtolower($lexer->lookahead['value']) !== 'query') {
+                $parser->syntaxError('query');
+            }
+            $parser->match(Lexer::T_IDENTIFIER);
+
+            if (strtolower($lexer->lookahead['value']) !== 'expansion') {
+                $parser->syntaxError('expansion');
+            }
+            $parser->match(Lexer::T_IDENTIFIER);
+
             $this->queryExpansion = true;
         }
 

--- a/tests/Query/Mysql/MatchAgainstTest.php
+++ b/tests/Query/Mysql/MatchAgainstTest.php
@@ -13,4 +13,36 @@ class MatchAgainstTest extends MysqlTestCase
             "SELECT MATCH (b0_.id) AGAINST ('3') AS sclr_0 FROM Blank b0_"
         );
     }
+
+    public function testMatchAgainstMultipleFields()
+    {
+        $this->assertDqlProducesSql(
+            "SELECT MATCH(post.longitude, post.latitude) AGAINST ('3') from DoctrineExtensions\Tests\Entities\BlogPost AS post",
+            "SELECT MATCH (b0_.longitude, b0_.latitude) AGAINST ('3') AS sclr_0 FROM BlogPost b0_"
+        );
+    }
+
+    public function testMatchAgainstInBooleanMode()
+    {
+        $this->assertDqlProducesSql(
+            "SELECT MATCH(blank.id) AGAINST ('+3 -4' BOOLEAN) from DoctrineExtensions\Tests\Entities\Blank AS blank",
+            "SELECT MATCH (b0_.id) AGAINST ('+3 -4' IN BOOLEAN MODE) AS sclr_0 FROM Blank b0_"
+        );
+        $this->assertDqlProducesSql(
+            "SELECT MATCH(blank.id) AGAINST ('+3 -4' IN BOOLEAN MODE) from DoctrineExtensions\Tests\Entities\Blank AS blank",
+            "SELECT MATCH (b0_.id) AGAINST ('+3 -4' IN BOOLEAN MODE) AS sclr_0 FROM Blank b0_"
+        );
+    }
+
+    public function testMatchAgainstWithQueryExpansion()
+    {
+        $this->assertDqlProducesSql(
+            "SELECT MATCH(blank.id) AGAINST ('3' EXPAND) from DoctrineExtensions\Tests\Entities\Blank AS blank",
+            "SELECT MATCH (b0_.id) AGAINST ('3' WITH QUERY EXPANSION) AS sclr_0 FROM Blank b0_"
+        );
+        $this->assertDqlProducesSql(
+            "SELECT MATCH(blank.id) AGAINST ('3' WITH QUERY EXPANSION) from DoctrineExtensions\Tests\Entities\Blank AS blank",
+            "SELECT MATCH (b0_.id) AGAINST ('3' WITH QUERY EXPANSION) AS sclr_0 FROM Blank b0_"
+        );
+    }
 }


### PR DESCRIPTION
I was wondering why the actual MySQL syntax was not working in the `MatchAgainst` function. I couldn't find any reason why and then I found in the source code that it was shortened to just "BOOLEAN" and "EXPAND". There's probably a good reason for that, but in case there isn't here is a change that allows both the documented MySQL variant and the shortened DQL versions.

Enlighten me =)