### PR TITLE
Fixed reference to class Doctrine\DBAL\Types\Type

### DIFF
--- a/src/Types/PolygonType.php
+++ b/src/Types/PolygonType.php
@@ -3,6 +3,7 @@
 namespace DoctrineExtensions\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\Type;
 
 class PolygonType extends Type
 {


### PR DESCRIPTION
A simple bug that prevents me from using the PolygonType class