### PR TITLE
Remove mention of non existing `IFELSE` DQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ Notes
 
 - MySQL `DATE_ADD` is available in DQL as `DATEADD(CURRENT_DATE(), 1, 'DAY')`
 - MySQL `DATE_SUB` is available in DQL as `DATESUB(CURRENT_DATE(), 1, 'DAY')`
-- MySQL `IF` is available in DQL as `IFELSE(field > 0, 'true', 'false')`
 
 Troubleshooting
 ---------------


### PR DESCRIPTION
The `IFELSE` is not a native function available in `doctrine/orm`, instead it must be added via this package, `beberlei/doctrineextensions`. So it should never have been mentioned in the first place as existing.