### PR TITLE
Migrate Travis from precise (12.04) to bionic (18.04)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,7 @@ script:
   - make test
   - if [[ $DOCTRINE_VERSION == 2.6.* && $TRAVIS_PHP_VERSION == 7.3 ]]; then make lint; fi
 
-sudo: false
-dist: precise
+dist: bionic
 
 cache:
   directories:


### PR DESCRIPTION
Precise is now deprecated as mentionned on
https://travis-ci.org/beberlei/DoctrineExtensions/jobs/563603191