### PR TITLE
Fixed exception that is thrown when combining the sqlite CONCAT_WS extension with a LimitSubqueryOutputWalker

### DIFF
--- a/src/Query/Sqlite/ConcatWs.php
+++ b/src/Query/Sqlite/ConcatWs.php
@@ -55,14 +55,14 @@ class ConcatWs extends FunctionNode
 
     public function getSql(\Doctrine\ORM\Query\SqlWalker $sqlWalker)
     {
-        $separator = array_shift($this->values)->simpleArithmeticExpression->value;
+        $separator = $this->values[0]->simpleArithmeticExpression->value;
 
         // Create an array to hold the query elements.
         $queryBuilder = ['('];
 
         // Iterate over the captured expressions and add them to the query.
-        for ($i = 0; $i < count($this->values); $i++) {
-            if ($i > 0) {
+        for ($i = 1; $i < count($this->values); $i++) {
+            if ($i > 1) {
                 $queryBuilder[] = " || '${separator}' || ";
             }
 

--- a/tests/Query/Sqlite/ConcatWsTest.php
+++ b/tests/Query/Sqlite/ConcatWsTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace DoctrineExtensions\Tests\Query\Sqlite;
+
+use DoctrineExtensions\Tests\Query\SqliteTestCase;
+
+class ConcatWsTest extends SqliteTestCase
+{
+    public function testConcatWs()
+    {
+        $dql = "SELECT CONCAT_WS(',', p.id, p.name) FROM DoctrineExtensions\\Tests\\Entities\\Product p";
+
+        $this->assertEquals(
+            "SELECT (IFNULL(p0_.id, '') || ',' || IFNULL(p0_.name, '')) AS {$this->columnAlias} FROM Product p0_",
+            $this->entityManager->createQuery($dql)->getSql()
+        );
+    }
+}


### PR DESCRIPTION
Using the `doctrine/orm` Paginator in combination with the `CONCAT_WS` sqlite extension results in the following exception being thrown:

```
Undefined property: Doctrine\ORM\Query\AST\PathExpression::$value
```

The exception is thrown because `array_shift` modifies the `$this->values` array when the sql is gotten for the first time. When the `LimitSubqueryOutputWalker` gets the sql for a second time the first element in the array is not a `\Doctrine\ORM\Query\AST\Literal` but a `\Doctrine\ORM\Query\AST\PathExpression` resulting in the above exception.

I've also added the missing unit test. 