### PR TITLE
fix undefined index error

### DIFF
--- a/src/Query/SortableNullsWalker.php
+++ b/src/Query/SortableNullsWalker.php
@@ -49,7 +49,9 @@ class SortableNullsWalker extends Query\SqlWalker
                 $dqlAlias = $expr->identificationVariable;
                 $search = $this->walkPathExpression($expr) . ' ' . $type;
                 $index = $dqlAlias . '.' . $fieldName;
-                $sql = str_replace($search, $search . ' ' . $hint[$index], $sql);
+                if (isset($hint[$index])) {
+                    $sql = str_replace($search, $search . ' ' . $hint[$index], $sql);
+                }
             }
         }
 


### PR DESCRIPTION
Hello,
This is a small fix, to prevent an error when the index (alias + field) is not found in the `$hint` array.
In this case, we can skip the `str_replace()` function call.