### PR TITLE
php 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         {"name": "Steve Lacey", "email": "steve@steve.ly"}
     ],
     "require": {
-        "php": "^7.1",
+        "php": ">=7.1",
         "doctrine/orm": "^2.6"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         {"name": "Steve Lacey", "email": "steve@steve.ly"}
     ],
     "require": {
-        "php": ">=7.1",
+        "php": "^7.1 || ^8.0",
         "doctrine/orm": "^2.6"
     },
     "require-dev": {


### PR DESCRIPTION
    - beberlei/doctrineextensions v1.2.9 requires php ^7.1 -> your PHP version (8.0.0) does not satisfy that requirement.
