### PR TITLE
Added match_type parameter for REGEXP function

### DIFF
--- a/tests/Query/Mysql/RegexpTest.php
+++ b/tests/Query/Mysql/RegexpTest.php
@@ -13,4 +13,12 @@ class RegexpTest extends MysqlTestCase
             "SELECT ('2' REGEXP '3') AS sclr_0 FROM Blank b0_"
         );
     }
+
+    public function testRegexpWithMatchType()
+    {
+        $this->assertDqlProducesSql(
+            "SELECT REGEXP('2', '3', 'c') from DoctrineExtensions\Tests\Entities\Blank b",
+            "SELECT REGEXP_LIKE('2', '3', 'c') AS sclr_0 FROM Blank b0_"
+        );
+    }
 }


### PR DESCRIPTION
In the current state it is not possible to specify how the matching should be performed (like case sensitive or insensitive matching). The MySQL documentation for this feature can be found here: https://dev.mysql.com/doc/refman/8.0/en/regexp.html#function_regexp-like