### PR TITLE
Fix visibility for methods overriding `TestCase::setUp()` and `TestCase::tearDown()`

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -75,6 +75,7 @@ $config = PhpCsFixer\Config::create()
         'phpdoc_trim' => true,
         'phpdoc_types' => true,
         'phpdoc_var_without_name' => true,
+        'php_unit_set_up_tear_down_visibility' => true,
         'psr4' => true,
         'self_accessor' => true,
         'semicolon_after_instruction' => true,

--- a/tests/Config/MysqlYamlTest.php
+++ b/tests/Config/MysqlYamlTest.php
@@ -14,7 +14,7 @@ class MysqlYamlTest extends TestCase
     /** @var array */
     protected $functions;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $yaml = new \Symfony\Component\Yaml\Parser();
 

--- a/tests/Query/DbTestCase.php
+++ b/tests/Query/DbTestCase.php
@@ -15,7 +15,7 @@ class DbTestCase extends TestCase
     /** @var Configuration */
     protected $configuration;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->configuration = new Configuration();
         $this->configuration->setMetadataCacheImpl(new ArrayCache());

--- a/tests/Query/Mysql/TrigTest.php
+++ b/tests/Query/Mysql/TrigTest.php
@@ -4,7 +4,7 @@ namespace DoctrineExtensions\Tests\Query\Mysql;
 
 class TrigTest extends \DoctrineExtensions\Tests\Query\MysqlTestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Query/MysqlTestCase.php
+++ b/tests/Query/MysqlTestCase.php
@@ -4,7 +4,7 @@ namespace DoctrineExtensions\Tests\Query;
 
 class MysqlTestCase extends DbTestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         ConfigLoader::load($this->configuration, ConfigLoader::MYSQL);

--- a/tests/Query/OracleTestCase.php
+++ b/tests/Query/OracleTestCase.php
@@ -4,7 +4,7 @@ namespace DoctrineExtensions\Tests\Query;
 
 class OracleTestCase extends DbTestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         ConfigLoader::load($this->configuration, ConfigLoader::ORACLE);

--- a/tests/Query/PostgresqlTestCase.php
+++ b/tests/Query/PostgresqlTestCase.php
@@ -4,7 +4,7 @@ namespace DoctrineExtensions\Tests\Query;
 
 class PostgresqlTestCase extends DbTestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         ConfigLoader::load($this->configuration, ConfigLoader::POSTGRES);

--- a/tests/Query/SqliteTestCase.php
+++ b/tests/Query/SqliteTestCase.php
@@ -9,7 +9,7 @@ class SqliteTestCase extends DbTestCase
      */
     protected $columnAlias;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         ConfigLoader::load($this->configuration, ConfigLoader::SQLITE);

--- a/tests/Types/CarbonDateTest.php
+++ b/tests/Types/CarbonDateTest.php
@@ -30,7 +30,7 @@ class CarbonDateTest extends TestCase
         Type::addType('CarbonImmutableTime', 'DoctrineExtensions\Types\CarbonImmutableTimeType');
     }
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $config = new \Doctrine\ORM\Configuration();
         $config->setMetadataCacheImpl(new \Doctrine\Common\Cache\ArrayCache());

--- a/tests/Types/ZendDateTest.php
+++ b/tests/Types/ZendDateTest.php
@@ -22,7 +22,7 @@ class ZendDateTest extends TestCase
         );
     }
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $config = new \Doctrine\ORM\Configuration();
         $config->setMetadataCacheImpl(new \Doctrine\Common\Cache\ArrayCache());


### PR DESCRIPTION
Also, the PHP-CS-Fixer rule `php_unit_set_up_tear_down_visibility` was configured to avoid regressions in the future.