### PR TITLE
Corrections to Oracle LISTAGG implementation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "friendsofphp/php-cs-fixer": "^2.14",
         "nesbot/carbon": "*",
         "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0",
+        "symfony/cache": "^5.3",
         "symfony/yaml": "^4.2 || ^5.0",
         "zf1/zend-date": "^1.12",
         "zf1/zend-registry": "^1.12"

--- a/src/Query/Oracle/Listagg.php
+++ b/src/Query/Oracle/Listagg.php
@@ -97,7 +97,7 @@ class Listagg extends FunctionNode
             $result .= ')';
         }
 
-        $result .= ' WITHIN GROUP (' . $sqlWalker->walkOrderByClause($this->orderBy) . ')';
+        $result .= ' WITHIN GROUP (' . ltrim($sqlWalker->walkOrderByClause($this->orderBy)) . ')';
 
         if (count($this->partitionBy)) {
             $partitionBy = [];
@@ -105,7 +105,7 @@ class Listagg extends FunctionNode
                 $partitionBy[] = $part->dispatch($sqlWalker);
             }
 
-            $result .= ' PARTITION BY (' . implode(',', $partitionBy) . ')';
+            $result .= ' OVER (PARTITION BY ' . implode(', ', $partitionBy) . ')';
         }
 
         return $result;

--- a/tests/Query/DbTestCase.php
+++ b/tests/Query/DbTestCase.php
@@ -2,9 +2,9 @@
 
 namespace DoctrineExtensions\Tests\Query;
 
-use Doctrine\Common\Cache\ArrayCache;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Tools\Setup;
 use PHPUnit\Framework\TestCase;
 
 class DbTestCase extends TestCase
@@ -17,13 +17,7 @@ class DbTestCase extends TestCase
 
     public function setUp(): void
     {
-        $this->configuration = new Configuration();
-        $this->configuration->setMetadataCacheImpl(new ArrayCache());
-        $this->configuration->setQueryCacheImpl(new ArrayCache());
-        $this->configuration->setProxyDir(__DIR__ . '/Proxies');
-        $this->configuration->setProxyNamespace('DoctrineExtensions\Tests\Proxies');
-        $this->configuration->setAutoGenerateProxyClasses(true);
-        $this->configuration->setMetadataDriverImpl($this->configuration->newDefaultAnnotationDriver(__DIR__ . '/../Entities'));
+        $this->configuration = Setup::createAnnotationMetadataConfiguration([__DIR__ . '/../Entities'], true);
         $this->entityManager = EntityManager::create(['driver' => 'pdo_sqlite', 'memory' => true ], $this->configuration);
     }
 

--- a/tests/Query/Oracle/ListaggTest.php
+++ b/tests/Query/Oracle/ListaggTest.php
@@ -14,7 +14,7 @@ class ListaggTest extends OracleTestCase
         $dql = "SELECT LISTAGG(p.id, ',') WITHIN GROUP (ORDER BY p.created) OVER (PARTITION BY p.longitude, p.latitude) FROM DoctrineExtensions\Tests\Entities\BlogPost p";
         $q = $this->entityManager->createQuery($dql);
 
-        $sql = "SELECT LISTAGG(b0_.id, ',') WITHIN GROUP ( ORDER BY b0_.created ASC) PARTITION BY (b0_.longitude,b0_.latitude) AS sclr_0 FROM BlogPost b0_";
+        $sql = "SELECT LISTAGG(b0_.id, ',') WITHIN GROUP (ORDER BY b0_.created ASC) OVER (PARTITION BY b0_.longitude, b0_.latitude) AS sclr_0 FROM BlogPost b0_";
         $this->assertEquals($sql, $q->getSql());
     }
 }

--- a/tests/Types/CarbonDateTest.php
+++ b/tests/Types/CarbonDateTest.php
@@ -6,6 +6,7 @@ use Carbon\Carbon;
 use Carbon\CarbonImmutable;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Tools\SchemaTool;
+use Doctrine\ORM\Tools\Setup;
 use DoctrineExtensions\Tests\Entities\CarbonDate as Entity;
 use PHPUnit\Framework\TestCase;
 
@@ -32,20 +33,12 @@ class CarbonDateTest extends TestCase
 
     public function setUp(): void
     {
-        $config = new \Doctrine\ORM\Configuration();
-        $config->setMetadataCacheImpl(new \Doctrine\Common\Cache\ArrayCache());
-        $config->setQueryCacheImpl(new \Doctrine\Common\Cache\ArrayCache());
-        $config->setProxyDir(__DIR__ . '/Proxies');
-        $config->setProxyNamespace('DoctrineExtensions\Tests\PHPUnit\Proxies');
-        $config->setAutoGenerateProxyClasses(true);
-        $config->setMetadataDriverImpl($config->newDefaultAnnotationDriver(__DIR__ . '/../../Entities'));
-
         $this->em = \Doctrine\ORM\EntityManager::create(
             [
                 'driver' => 'pdo_sqlite',
                 'memory' => true,
             ],
-            $config
+            Setup::createAnnotationMetadataConfiguration([__DIR__ . '/../Entities'], true)
         );
 
         $schemaTool = new SchemaTool($this->em);

--- a/tests/Types/ZendDateTest.php
+++ b/tests/Types/ZendDateTest.php
@@ -3,6 +3,7 @@
 namespace DoctrineExtensions\Tests\Types;
 
 use Doctrine\ORM\Tools\SchemaTool;
+use Doctrine\ORM\Tools\Setup;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -24,20 +25,12 @@ class ZendDateTest extends TestCase
 
     public function setUp(): void
     {
-        $config = new \Doctrine\ORM\Configuration();
-        $config->setMetadataCacheImpl(new \Doctrine\Common\Cache\ArrayCache());
-        $config->setQueryCacheImpl(new \Doctrine\Common\Cache\ArrayCache());
-        $config->setProxyDir(__DIR__ . '/Proxies');
-        $config->setProxyNamespace('DoctrineExtensions\Tests\PHPUnit\Proxies');
-        $config->setAutoGenerateProxyClasses(true);
-        $config->setMetadataDriverImpl($config->newDefaultAnnotationDriver(__DIR__ . '/../../Entities'));
-
         $this->em = \Doctrine\ORM\EntityManager::create(
             [
                 'driver' => 'pdo_sqlite',
                 'memory' => true,
             ],
-            $config
+            Setup::createAnnotationMetadataConfiguration([__DIR__ . '/../Entities'], true)
         );
 
         $schemaTool = new SchemaTool($this->em);


### PR DESCRIPTION
Use simple Doctrine Configuration setup which uses Symfony cache internally

This change is caused by https://github.com/doctrine/cache/issues/354