### PR TITLE
test: fix tests with downgrade to doctrine/cache v1 because of ArrayC…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.14",
         "nesbot/carbon": "*",
+        "doctrine/cache": "^1.11",
         "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0",
         "symfony/yaml": "^4.4 || ^5.3 || ^6.0",
         "zf1/zend-date": "^1.12",


### PR DESCRIPTION
…ache

This fixes the tests.
Of course an replacement with symfony/cache is a better solution in the long  run.