### PR TITLE
Fix CI & update PHP versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: PHP ${{ matrix.php }}
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     strategy:
       matrix:
@@ -18,6 +18,8 @@ jobs:
           - 7.2
           - 7.3
           - 7.4
+          - 8.0
+          - 8.1
 
     steps:
       - uses: actions/checkout@v2

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         "doctrine/orm": "^2.7"
     },
     "require-dev": {
+        "doctrine/cache": "^1.0",
         "friendsofphp/php-cs-fixer": "^2.14",
         "nesbot/carbon": "*",
         "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0",


### PR DESCRIPTION
Currently `master` build is broken because the `Doctrine\Common\Cache\ArrayCache` which has been removed in latest `doctrine/cache` versions (indirectly required by `doctrine/orm`).

As this class is used only for tests, I've added `doctrine/cache` 1.x branch as `require-dev` dependency.

I've also added latest PHP versions to ensure everything is fine with latest maintained PHP versions.