### PR TITLE
Allow expression in DatePart

### DIFF
--- a/src/Query/Postgresql/DatePart.php
+++ b/src/Query/Postgresql/DatePart.php
@@ -22,7 +22,7 @@ class DatePart extends FunctionNode
         $parser->match(Lexer::T_OPEN_PARENTHESIS);
         $this->dateString = $parser->ArithmeticPrimary();
         $parser->match(Lexer::T_COMMA);
-        $this->dateFormat = $parser->ArithmeticPrimary();
+        $this->dateFormat = $parser->ArithmeticExpression();
         $parser->match(Lexer::T_CLOSE_PARENTHESIS);
     }
 


### PR DESCRIPTION
This modification allows usage of 

`DATE_PART('day', columnA - columnB)`

instead of restricting usage to 

`DATE_PART('week', columnA)`