### PR TITLE
Add Timezone option to dateTrunc

### DIFF
--- a/src/Query/Postgresql/DateTrunc.php
+++ b/src/Query/Postgresql/DateTrunc.php
@@ -13,6 +13,8 @@ class DateTrunc extends FunctionNode
 
     public $fieldTimestamp = null;
 
+    public $fieldTimezone = null;
+
     public function parse(Parser $parser): void
     {
         $parser->match(Lexer::T_IDENTIFIER);
@@ -20,15 +22,27 @@ class DateTrunc extends FunctionNode
         $this->fieldText = $parser->ArithmeticPrimary();
         $parser->match(Lexer::T_COMMA);
         $this->fieldTimestamp = $parser->ArithmeticPrimary();
+        if ($parser->getLexer()->lookahead['type'] === Lexer::T_COMMA) {
+            $parser->match(Lexer::T_COMMA);
+            $this->fieldTimezone = $parser->ArithmeticPrimary();
+        }
         $parser->match(Lexer::T_CLOSE_PARENTHESIS);
     }
 
     public function getSql(SqlWalker $sqlWalker): string
     {
-        return sprintf(
-            'DATE_TRUNC(%s, %s)',
+        $sql = sprintf(
+            'DATE_TRUNC(%s, %s',
             $this->fieldText->dispatch($sqlWalker),
             $this->fieldTimestamp->dispatch($sqlWalker)
         );
+
+        if ($this->fieldTimezone !== null) {
+            $sql .= sprintf(', %s', $this->fieldTimezone->dispatch($sqlWalker));
+        }
+
+        $sql .= ')';
+
+        return $sql;
     }
 }


### PR DESCRIPTION
The DateTrunc function did not take the optional third timezone argument.

With this change it will work the same if it is not passed but, if you need it, you can add the parameter