### PR TITLE
Avoid deprecations with Doctrine/lexer 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": "^7.2 || ^8.0",
-        "doctrine/orm": "^2.7"
+        "doctrine/orm": "^2.15"
     },
     "require-dev": {
         "doctrine/cache": "^1.11",

--- a/src/Query/Mysql/Cast.php
+++ b/src/Query/Mysql/Cast.php
@@ -40,7 +40,7 @@ class Cast extends FunctionNode
         $parser->match(Lexer::T_AS);
         $parser->match(Lexer::T_IDENTIFIER);
 
-        $type = $parser->getLexer()->token['value'];
+        $type = $parser->getLexer()->token->value;
 
         if ($parser->getLexer()->isNextToken(Lexer::T_OPEN_PARENTHESIS)) {
             $parser->match(Lexer::T_OPEN_PARENTHESIS);

--- a/src/Query/Mysql/Collate.php
+++ b/src/Query/Mysql/Collate.php
@@ -36,7 +36,7 @@ class Collate extends FunctionNode
 
         $lexer = $parser->getLexer();
 
-        $this->collation = $lexer->token['value'];
+        $this->collation = $lexer->token->value;
 
         $parser->match(Lexer::T_CLOSE_PARENTHESIS);
     }

--- a/src/Query/Mysql/ConcatWs.php
+++ b/src/Query/Mysql/ConcatWs.php
@@ -27,17 +27,17 @@ class ConcatWs extends FunctionNode
 
         $lexer = $parser->getLexer();
 
-        while (count($this->values) < 3 || $lexer->lookahead['type'] == Lexer::T_COMMA) {
+        while (count($this->values) < 3 || $lexer->lookahead->type == Lexer::T_COMMA) {
             $parser->match(Lexer::T_COMMA);
             $peek = $lexer->glimpse();
 
-            $this->values[] = $peek['value'] == '('
+            $this->values[] = $peek->value == '('
                     ? $parser->FunctionDeclaration()
                     : $parser->ArithmeticExpression();
         }
 
-        while ($lexer->lookahead['type'] == Lexer::T_IDENTIFIER) {
-            switch (strtolower($lexer->lookahead['value'])) {
+        while ($lexer->lookahead->type == Lexer::T_IDENTIFIER) {
+            switch (strtolower($lexer->lookahead->value)) {
                 case 'notempty':
                     $parser->match(Lexer::T_IDENTIFIER);
                     $this->notEmpty = true;

--- a/src/Query/Mysql/CountIf.php
+++ b/src/Query/Mysql/CountIf.php
@@ -26,8 +26,8 @@ class CountIf extends FunctionNode
 
         $lexer = $parser->getLexer();
 
-        while ($lexer->lookahead['type'] == Lexer::T_IDENTIFIER) {
-            switch (strtolower($lexer->lookahead['value'])) {
+        while ($lexer->lookahead->type == Lexer::T_IDENTIFIER) {
+            switch (strtolower($lexer->lookahead->value)) {
                 case 'inverse':
                     $parser->match(Lexer::T_IDENTIFIER);
                     $this->inverse = true;

--- a/src/Query/Mysql/Extract.php
+++ b/src/Query/Mysql/Extract.php
@@ -21,7 +21,7 @@ class Extract extends DateAdd
 
         $parser->match(Lexer::T_IDENTIFIER);
         $lexer = $parser->getLexer();
-        $this->unit = $lexer->token['value'];
+        $this->unit = $lexer->token->value;
 
         $parser->match(Lexer::T_IDENTIFIER);
         $this->date = $parser->ArithmeticPrimary();

--- a/src/Query/Mysql/Field.php
+++ b/src/Query/Mysql/Field.php
@@ -28,7 +28,7 @@ class Field extends FunctionNode
         $lexer = $parser->getLexer();
 
         while (count($this->values) < 1 ||
-            $lexer->lookahead['type'] != Lexer::T_CLOSE_PARENTHESIS) {
+            $lexer->lookahead->type != Lexer::T_CLOSE_PARENTHESIS) {
             $parser->match(Lexer::T_COMMA);
             $this->values[] = $parser->ArithmeticPrimary();
         }

--- a/src/Query/Mysql/FromUnixtime.php
+++ b/src/Query/Mysql/FromUnixtime.php
@@ -37,7 +37,7 @@ class FromUnixtime extends FunctionNode
         $this->firstExpression = $parser->ArithmeticPrimary();
 
         // parse second parameter if available
-        if (Lexer::T_COMMA === $lexer->lookahead['type']) {
+        if (Lexer::T_COMMA === $lexer->lookahead->type) {
             $parser->match(Lexer::T_COMMA);
             $this->secondExpression = $parser->ArithmeticPrimary();
         }

--- a/src/Query/Mysql/Greatest.php
+++ b/src/Query/Mysql/Greatest.php
@@ -28,7 +28,7 @@ class Greatest extends FunctionNode
         $lexer = $parser->getLexer();
 
         while (count($this->values) < 1 ||
-            $lexer->lookahead['type'] != Lexer::T_CLOSE_PARENTHESIS) {
+            $lexer->lookahead->type != Lexer::T_CLOSE_PARENTHESIS) {
             $parser->match(Lexer::T_COMMA);
             $this->values[] = $parser->ArithmeticExpression();
         }

--- a/src/Query/Mysql/GroupConcat.php
+++ b/src/Query/Mysql/GroupConcat.php
@@ -45,7 +45,7 @@ class GroupConcat extends FunctionNode
         }
 
         if ($lexer->isNextToken(Lexer::T_IDENTIFIER)) {
-            if (strtolower($lexer->lookahead['value']) !== 'separator') {
+            if (strtolower($lexer->lookahead->value) !== 'separator') {
                 $parser->syntaxError('separator');
             }
             $parser->match(Lexer::T_IDENTIFIER);

--- a/src/Query/Mysql/Least.php
+++ b/src/Query/Mysql/Least.php
@@ -27,7 +27,7 @@ class Least extends FunctionNode
         $lexer = $parser->getLexer();
 
         while (count($this->values) < 1 ||
-            $lexer->lookahead['type'] != Lexer::T_CLOSE_PARENTHESIS) {
+            $lexer->lookahead->type != Lexer::T_CLOSE_PARENTHESIS) {
             $parser->match(Lexer::T_COMMA);
             $this->values[] = $parser->ArithmeticExpression();
         }

--- a/src/Query/Mysql/MatchAgainst.php
+++ b/src/Query/Mysql/MatchAgainst.php
@@ -39,7 +39,7 @@ class MatchAgainst extends FunctionNode
         $parser->match(Lexer::T_CLOSE_PARENTHESIS);
 
         // against
-        if (strtolower($lexer->lookahead['value']) !== 'against') {
+        if (strtolower($lexer->lookahead->value) !== 'against') {
             $parser->syntaxError('against');
         }
 
@@ -47,18 +47,18 @@ class MatchAgainst extends FunctionNode
         $parser->match(Lexer::T_OPEN_PARENTHESIS);
         $this->against = $parser->StringPrimary();
 
-        if (strtolower($lexer->lookahead['value']) === 'boolean') {
+        if (strtolower($lexer->lookahead->value) === 'boolean') {
             $parser->match(Lexer::T_IDENTIFIER);
             $this->booleanMode = true;
-        } elseif (strtolower($lexer->lookahead['value']) === 'in') {
+        } elseif (strtolower($lexer->lookahead->value) === 'in') {
             $parser->match(Lexer::T_IDENTIFIER);
 
-            if (strtolower($lexer->lookahead['value']) !== 'boolean') {
+            if (strtolower($lexer->lookahead->value) !== 'boolean') {
                 $parser->syntaxError('boolean');
             }
             $parser->match(Lexer::T_IDENTIFIER);
 
-            if (strtolower($lexer->lookahead['value']) !== 'mode') {
+            if (strtolower($lexer->lookahead->value) !== 'mode') {
                 $parser->syntaxError('mode');
             }
             $parser->match(Lexer::T_IDENTIFIER);
@@ -66,18 +66,18 @@ class MatchAgainst extends FunctionNode
             $this->booleanMode = true;
         }
 
-        if (strtolower($lexer->lookahead['value']) === 'expand') {
+        if (strtolower($lexer->lookahead->value) === 'expand') {
             $parser->match(Lexer::T_IDENTIFIER);
             $this->queryExpansion = true;
-        } elseif (strtolower($lexer->lookahead['value']) === 'with') {
+        } elseif (strtolower($lexer->lookahead->value) === 'with') {
             $parser->match(Lexer::T_IDENTIFIER);
 
-            if (strtolower($lexer->lookahead['value']) !== 'query') {
+            if (strtolower($lexer->lookahead->value) !== 'query') {
                 $parser->syntaxError('query');
             }
             $parser->match(Lexer::T_IDENTIFIER);
 
-            if (strtolower($lexer->lookahead['value']) !== 'expansion') {
+            if (strtolower($lexer->lookahead->value) !== 'expansion') {
                 $parser->syntaxError('expansion');
             }
             $parser->match(Lexer::T_IDENTIFIER);

--- a/src/Query/Mysql/Rand.php
+++ b/src/Query/Mysql/Rand.php
@@ -28,7 +28,7 @@ class Rand extends FunctionNode
         $parser->match(Lexer::T_IDENTIFIER);
         $parser->match(Lexer::T_OPEN_PARENTHESIS);
 
-        if (Lexer::T_CLOSE_PARENTHESIS !== $lexer->lookahead['type']) {
+        if (Lexer::T_CLOSE_PARENTHESIS !== $lexer->lookahead->type) {
             $this->expression = $parser->SimpleArithmeticExpression();
         }
 

--- a/src/Query/Mysql/Round.php
+++ b/src/Query/Mysql/Round.php
@@ -19,7 +19,7 @@ class Round extends FunctionNode
         $this->firstExpression = $parser->SimpleArithmeticExpression();
 
         // parse second parameter if available
-        if (Lexer::T_COMMA === $lexer->lookahead['type']) {
+        if (Lexer::T_COMMA === $lexer->lookahead->type) {
             $parser->match(Lexer::T_COMMA);
             $this->secondExpression = $parser->ArithmeticPrimary();
         }

--- a/src/Query/Mysql/TimestampAdd.php
+++ b/src/Query/Mysql/TimestampAdd.php
@@ -22,7 +22,7 @@ class TimestampAdd extends FunctionNode
         $parser->match(Lexer::T_OPEN_PARENTHESIS);
         $parser->match(Lexer::T_IDENTIFIER);
         $lexer = $parser->getLexer();
-        $this->unit = $lexer->token['value'];
+        $this->unit = $lexer->token->value;
         $parser->match(Lexer::T_COMMA);
         $this->firstDatetimeExpression = $parser->ArithmeticPrimary();
         $parser->match(Lexer::T_COMMA);

--- a/src/Query/Mysql/TimestampDiff.php
+++ b/src/Query/Mysql/TimestampDiff.php
@@ -22,7 +22,7 @@ class TimestampDiff extends FunctionNode
         $parser->match(Lexer::T_OPEN_PARENTHESIS);
         $parser->match(Lexer::T_IDENTIFIER);
         $lexer = $parser->getLexer();
-        $this->unit = $lexer->token['value'];
+        $this->unit = $lexer->token->value;
         $parser->match(Lexer::T_COMMA);
         $this->firstDatetimeExpression = $parser->ArithmeticPrimary();
         $parser->match(Lexer::T_COMMA);

--- a/src/Query/Mysql/Week.php
+++ b/src/Query/Mysql/Week.php
@@ -34,7 +34,7 @@ class Week extends FunctionNode
 
         $this->date = $parser->ArithmeticPrimary();
 
-        if (Lexer::T_COMMA === $parser->getLexer()->lookahead['type']) {
+        if (Lexer::T_COMMA === $parser->getLexer()->lookahead->type) {
             $parser->match(Lexer::T_COMMA);
             $this->mode = $parser->Literal();
         }

--- a/src/Query/Mysql/YearWeek.php
+++ b/src/Query/Mysql/YearWeek.php
@@ -32,7 +32,7 @@ class YearWeek extends FunctionNode
 
         $this->date = $parser->ArithmeticPrimary();
 
-        if (Lexer::T_COMMA === $parser->getLexer()->lookahead['type']) {
+        if (Lexer::T_COMMA === $parser->getLexer()->lookahead->type) {
             $parser->match(Lexer::T_COMMA);
             $this->mode = $parser->Literal();
         }

--- a/src/Query/Oracle/Listagg.php
+++ b/src/Query/Oracle/Listagg.php
@@ -51,7 +51,7 @@ class Listagg extends FunctionNode
         }
         $parser->match(Lexer::T_CLOSE_PARENTHESIS);
 
-        if (!$lexer->isNextToken(Lexer::T_IDENTIFIER) || strtolower($lexer->lookahead['value']) != 'within') {
+        if (!$lexer->isNextToken(Lexer::T_IDENTIFIER) || strtolower($lexer->lookahead->value) != 'within') {
             $parser->syntaxError('WITHIN GROUP');
         }
         $parser->match(Lexer::T_IDENTIFIER);
@@ -62,13 +62,13 @@ class Listagg extends FunctionNode
         $parser->match(Lexer::T_CLOSE_PARENTHESIS);
 
         if ($lexer->isNextToken(Lexer::T_IDENTIFIER)) {
-            if (strtolower($lexer->lookahead['value']) != 'over') {
+            if (strtolower($lexer->lookahead->value) != 'over') {
                 $parser->syntaxError('OVER');
             }
             $parser->match(Lexer::T_IDENTIFIER);
             $parser->match(Lexer::T_OPEN_PARENTHESIS);
 
-            if (!$lexer->isNextToken(Lexer::T_IDENTIFIER) || strtolower($lexer->lookahead['value']) != 'partition') {
+            if (!$lexer->isNextToken(Lexer::T_IDENTIFIER) || strtolower($lexer->lookahead->value) != 'partition') {
                 $parser->syntaxError('PARTITION BY');
             }
             $parser->match(Lexer::T_IDENTIFIER);

--- a/src/Query/Postgresql/ExtractFunction.php
+++ b/src/Query/Postgresql/ExtractFunction.php
@@ -44,7 +44,7 @@ class ExtractFunction extends FunctionNode
         $parser->match(Lexer::T_OPEN_PARENTHESIS);
 
         $parser->match(Lexer::T_IDENTIFIER);
-        $this->field = $parser->getLexer()->token['value'];
+        $this->field = $parser->getLexer()->token->value;
 
         $parser->match(Lexer::T_FROM);
 

--- a/src/Query/Postgresql/Greatest.php
+++ b/src/Query/Postgresql/Greatest.php
@@ -29,7 +29,7 @@ class Greatest extends FunctionNode
         $lexer = $parser->getLexer();
 
         while (count($this->values) < 1 ||
-            $lexer->lookahead['type'] != Lexer::T_CLOSE_PARENTHESIS) {
+            $lexer->lookahead->type != Lexer::T_CLOSE_PARENTHESIS) {
             $parser->match(Lexer::T_COMMA);
             $this->values[] = $parser->ArithmeticExpression();
         }

--- a/src/Query/Postgresql/Least.php
+++ b/src/Query/Postgresql/Least.php
@@ -28,7 +28,7 @@ class Least extends FunctionNode
         $lexer = $parser->getLexer();
 
         while (count($this->values) < 1 ||
-            $lexer->lookahead['type'] != Lexer::T_CLOSE_PARENTHESIS) {
+            $lexer->lookahead->type != Lexer::T_CLOSE_PARENTHESIS) {
             $parser->match(Lexer::T_COMMA);
             $this->values[] = $parser->ArithmeticExpression();
         }

--- a/src/Query/Sqlite/ConcatWs.php
+++ b/src/Query/Sqlite/ConcatWs.php
@@ -27,17 +27,17 @@ class ConcatWs extends FunctionNode
 
         $lexer = $parser->getLexer();
 
-        while (count($this->values) < 3 || $lexer->lookahead['type'] == Lexer::T_COMMA) {
+        while (count($this->values) < 3 || $lexer->lookahead->type == Lexer::T_COMMA) {
             $parser->match(Lexer::T_COMMA);
             $peek = $lexer->glimpse();
 
-            $this->values[] = $peek['value'] == '('
+            $this->values[] = $peek->value == '('
                 ? $parser->FunctionDeclaration()
                 : $parser->ArithmeticExpression();
         }
 
-        while ($lexer->lookahead['type'] == Lexer::T_IDENTIFIER) {
-            switch (strtolower($lexer->lookahead['value'])) {
+        while ($lexer->lookahead->type == Lexer::T_IDENTIFIER) {
+            switch (strtolower($lexer->lookahead->value)) {
                 case 'notempty':
                     $parser->match(Lexer::T_IDENTIFIER);
                     $this->notEmpty = true;

--- a/src/Query/Sqlite/Greatest.php
+++ b/src/Query/Sqlite/Greatest.php
@@ -28,7 +28,7 @@ class Greatest extends FunctionNode
         $lexer = $parser->getLexer();
 
         while (count($this->values) < 1 ||
-            $lexer->lookahead['type'] != Lexer::T_CLOSE_PARENTHESIS) {
+            $lexer->lookahead->type != Lexer::T_CLOSE_PARENTHESIS) {
             $parser->match(Lexer::T_COMMA);
             $this->values[] = $parser->ArithmeticExpression();
         }

--- a/src/Query/Sqlite/Least.php
+++ b/src/Query/Sqlite/Least.php
@@ -27,7 +27,7 @@ class Least extends FunctionNode
         $lexer = $parser->getLexer();
 
         while (count($this->values) < 1 ||
-            $lexer->lookahead['type'] != Lexer::T_CLOSE_PARENTHESIS) {
+            $lexer->lookahead->type != Lexer::T_CLOSE_PARENTHESIS) {
             $parser->match(Lexer::T_COMMA);
             $this->values[] = $parser->ArithmeticExpression();
         }

--- a/src/Query/Sqlite/Round.php
+++ b/src/Query/Sqlite/Round.php
@@ -22,7 +22,7 @@ class Round extends FunctionNode
         $this->firstExpression = $parser->SimpleArithmeticExpression();
 
         // parse second parameter if available
-        if (Lexer::T_COMMA === $lexer->lookahead['type']) {
+        if (Lexer::T_COMMA === $lexer->lookahead->type) {
             $parser->match(Lexer::T_COMMA);
             $this->secondExpression = $parser->ArithmeticPrimary();
         }

--- a/src/Query/Sqlite/Week.php
+++ b/src/Query/Sqlite/Week.php
@@ -22,7 +22,7 @@ class Week extends NumberFromStrfTime
 
         $this->date = $parser->ArithmeticPrimary();
 
-        if (Lexer::T_COMMA === $parser->getLexer()->lookahead['type']) {
+        if (Lexer::T_COMMA === $parser->getLexer()->lookahead->type) {
             $parser->match(Lexer::T_COMMA);
             $this->mode = $parser->Literal();
         }


### PR DESCRIPTION
Hi @beberlei,

I know this library is in a low maintenance mode (no issue, no release) but I think you still accept some PR (if you don't, my bad).

Last year, doctrine/lexer 2 was released with a Token array-like class.
Things like `$lexer->lookahead['type']` are deprecated in favor of `$lexer->lookahead->type`.

When using doctrineExtensions with doctrine/lexer 2, multiples deprecations are thrown because the old syntax were used.
In this PR:
- I bumped the minimum requirement of doctrine/orm to ^2.15 which is the lowest requiring doctrine/lexer 2
- I changed all the array-access on Token to property call