### PR TITLE
Force typing for Postgresql::`date_trunc` so it can be used in a condition

### DIFF
--- a/src/Query/Postgresql/DateTrunc.php
+++ b/src/Query/Postgresql/DateTrunc.php
@@ -28,7 +28,7 @@ class DateTrunc extends FunctionNode
     public function getSql(SqlWalker $sqlWalker): string
     {
         return sprintf(
-            'DATE_TRUNC(%s, %s)',
+            'DATE_TRUNC(%s::text, %s::timestamp)',
             $this->fieldText->dispatch($sqlWalker),
             $this->fieldTimestamp->dispatch($sqlWalker)
         );

--- a/tests/Query/Postgresql/DateTruncTest.php
+++ b/tests/Query/Postgresql/DateTruncTest.php
@@ -2,6 +2,7 @@
 
 namespace DoctrineExtensions\Tests\Query\Postgresql;
 
+use DateTime;
 use Doctrine\ORM\QueryBuilder;
 use DoctrineExtensions\Tests\Entities\Date;
 use DoctrineExtensions\Tests\Query\PostgresqlTestCase;
@@ -20,16 +21,15 @@ class DateTruncTest extends PostgresqlTestCase
         $this->assertEquals($expected, $queryBuilder->getQuery()->getSQL());
     }
 
-    public function testDateTruncCondition()
+    public function testDateTruncCondition(): void
     {
         $queryBuilder = $this->entityManager->getRepository(Date::class)
             ->createQueryBuilder('dt')
             ->where("date_trunc('YEAR', dt.created) = date_trunc('YEAR', :date)")
-            ->setParameter('date', new \DateTime('2010-01-01'));
+            ->setParameter('date', new DateTime('2010-01-01'));
 
         $expected = "SELECT d0_.id AS id_0, d0_.created AS created_1 FROM Date d0_ WHERE DATE_TRUNC('YEAR'::text, d0_.created::timestamp) = DATE_TRUNC('YEAR'::text, ?::timestamp)";
 
         $this->assertEquals($expected, $queryBuilder->getQuery()->getSQL());
-
     }
 }

--- a/tests/Query/Postgresql/DateTruncTest.php
+++ b/tests/Query/Postgresql/DateTruncTest.php
@@ -3,6 +3,7 @@
 namespace DoctrineExtensions\Tests\Query\Postgresql;
 
 use Doctrine\ORM\QueryBuilder;
+use DoctrineExtensions\Tests\Entities\Date;
 use DoctrineExtensions\Tests\Query\PostgresqlTestCase;
 
 class DateTruncTest extends PostgresqlTestCase
@@ -14,8 +15,21 @@ class DateTruncTest extends PostgresqlTestCase
             ->select("date_trunc('YEAR', dt.created)")
             ->from('DoctrineExtensions\Tests\Entities\Date', 'dt');
 
-        $expected = "SELECT DATE_TRUNC('YEAR', d0_.created) AS sclr_0 FROM Date d0_";
+        $expected = "SELECT DATE_TRUNC('YEAR'::text, d0_.created::timestamp) AS sclr_0 FROM Date d0_";
 
         $this->assertEquals($expected, $queryBuilder->getQuery()->getSQL());
+    }
+
+    public function testDateTruncCondition()
+    {
+        $queryBuilder = $this->entityManager->getRepository(Date::class)
+            ->createQueryBuilder('dt')
+            ->where("date_trunc('YEAR', dt.created) = date_trunc('YEAR', :date)")
+            ->setParameter('date', new \DateTime('2010-01-01'));
+
+        $expected = "SELECT d0_.id AS id_0, d0_.created AS created_1 FROM Date d0_ WHERE DATE_TRUNC('YEAR'::text, d0_.created::timestamp) = DATE_TRUNC('YEAR'::text, ?::timestamp)";
+
+        $this->assertEquals($expected, $queryBuilder->getQuery()->getSQL());
+
     }
 }


### PR DESCRIPTION
I had the use case today to use date_trunc inside a query builder `->where` statement and the lexer was lost because of an error like this:

```
An exception occurred while executing a query: SQLSTATE[42725]: Ambiguous function: 7 ERROR: function date_trunc(unknown, unknown) is not unique
LINE 1: ...pany_id = $1 AND DATE_TRUNC($2, p1_.created_at) = DATE_TRUNC...
```
This simple solution ensures postgresql knows what to expect.