### PR TITLE
Added test for using MatchAgainst in where clause

### DIFF
--- a/tests/Query/Mysql/MatchAgainstTest.php
+++ b/tests/Query/Mysql/MatchAgainstTest.php
@@ -14,6 +14,14 @@ class MatchAgainstTest extends MysqlTestCase
         );
     }
 
+    public function testMatchAgainstInWhereClause(): void
+    {
+        $this->assertDqlProducesSql(
+            "SELECT blank FROM DoctrineExtensions\Tests\Entities\Blank AS blank WHERE MATCH(blank.id) AGAINST ('3')",
+            "SELECT b0_.id AS id_0 FROM Blank b0_ WHERE MATCH (b0_.id) AGAINST ('3')"
+        );
+    }
+
     public function testMatchAgainstMultipleFields()
     {
         $this->assertDqlProducesSql(


### PR DESCRIPTION
I have added a unit test to show that the current MatchAgainst does not work in a where clause. I think the reason is that the DQL parser thinks it is a simple conditional expression and expects an operator after the `AGAINST(...)` token. 

One can workaround this by adding `> 0` to the condition:
```patch
  SELECT blank 
  FROM DoctrineExtensions\Tests\Entities\Blank AS blank 
- WHERE MATCH(blank.id) AGAINST ('3')
+ WHERE MATCH(blank.id) AGAINST ('3') > 0
```

I do not know if this should or can be fixed. But if not, it would be good to add a note somewhere. I can do that if I get a hint where to place it.