### PR TITLE
Fix ArrayAccess deprecation notice

### DIFF
--- a/src/Query/Mysql/Field.php
+++ b/src/Query/Mysql/Field.php
@@ -28,7 +28,7 @@ class Field extends FunctionNode
         $lexer = $parser->getLexer();
 
         while (count($this->values) < 1 ||
-            $lexer->lookahead['type'] != Lexer::T_CLOSE_PARENTHESIS) {
+            $lexer->lookahead->type != Lexer::T_CLOSE_PARENTHESIS) {
             $parser->match(Lexer::T_COMMA);
             $this->values[] = $parser->ArithmeticPrimary();
         }

--- a/src/Query/Mysql/MatchAgainst.php
+++ b/src/Query/Mysql/MatchAgainst.php
@@ -39,7 +39,7 @@ class MatchAgainst extends FunctionNode
         $parser->match(Lexer::T_CLOSE_PARENTHESIS);
 
         // against
-        if (strtolower($lexer->lookahead['value']) !== 'against') {
+        if (strtolower($lexer->lookahead->value) !== 'against') {
             $parser->syntaxError('against');
         }
 
@@ -47,18 +47,18 @@ class MatchAgainst extends FunctionNode
         $parser->match(Lexer::T_OPEN_PARENTHESIS);
         $this->against = $parser->StringPrimary();
 
-        if (strtolower($lexer->lookahead['value']) === 'boolean') {
+        if (strtolower($lexer->lookahead->value) === 'boolean') {
             $parser->match(Lexer::T_IDENTIFIER);
             $this->booleanMode = true;
-        } elseif (strtolower($lexer->lookahead['value']) === 'in') {
+        } elseif (strtolower($lexer->lookahead->value) === 'in') {
             $parser->match(Lexer::T_IDENTIFIER);
 
-            if (strtolower($lexer->lookahead['value']) !== 'boolean') {
+            if (strtolower($lexer->lookahead->value) !== 'boolean') {
                 $parser->syntaxError('boolean');
             }
             $parser->match(Lexer::T_IDENTIFIER);
 
-            if (strtolower($lexer->lookahead['value']) !== 'mode') {
+            if (strtolower($lexer->lookahead->value) !== 'mode') {
                 $parser->syntaxError('mode');
             }
             $parser->match(Lexer::T_IDENTIFIER);
@@ -66,18 +66,18 @@ class MatchAgainst extends FunctionNode
             $this->booleanMode = true;
         }
 
-        if (strtolower($lexer->lookahead['value']) === 'expand') {
+        if (strtolower($lexer->lookahead->value) === 'expand') {
             $parser->match(Lexer::T_IDENTIFIER);
             $this->queryExpansion = true;
-        } elseif (strtolower($lexer->lookahead['value']) === 'with') {
+        } elseif (strtolower($lexer->lookahead->value) === 'with') {
             $parser->match(Lexer::T_IDENTIFIER);
 
-            if (strtolower($lexer->lookahead['value']) !== 'query') {
+            if (strtolower($lexer->lookahead->value) !== 'query') {
                 $parser->syntaxError('query');
             }
             $parser->match(Lexer::T_IDENTIFIER);
 
-            if (strtolower($lexer->lookahead['value']) !== 'expansion') {
+            if (strtolower($lexer->lookahead->value) !== 'expansion') {
                 $parser->syntaxError('expansion');
             }
             $parser->match(Lexer::T_IDENTIFIER);


### PR DESCRIPTION
Newer versions of doctrine/lexer will produce this deprecation notice: `Accessing Doctrine\Common\Lexer\Token properties via ArrayAccess is deprecated, use the value, type or position property instead`