### PR TITLE
Bump workflow action version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
       - run: composer validate
 
       - id: composer-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: vendor
           key: php-${{ matrix.php }}-${{ hashFiles('**/composer.lock') }}


### PR DESCRIPTION
Node.js 16 actions are deprecated. v4 uses Node.js 20