### PR TITLE
Remove Doctrine Cache

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,12 @@
     },
     "require-dev": {
         "doctrine/annotations": "^1.14",
-        "doctrine/cache": "^1.11",
         "doctrine/coding-standard": "^9.0.2 || ^12.0",
         "nesbot/carbon": "*",
         "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0",
         "squizlabs/php_codesniffer": "^3.8",
-        "symfony/yaml": "^4.4 || ^5.3 || ^6.0",
+        "symfony/cache": "^4.4 || ^5.4 || ^6.4 || ^7.0",
+        "symfony/yaml": "^4.4 || ^5.3 || ^6.0 || ^7.0",
         "zf1/zend-date": "^1.12",
         "zf1/zend-registry": "^1.12"
     },

--- a/tests/Query/DbTestCase.php
+++ b/tests/Query/DbTestCase.php
@@ -2,10 +2,10 @@
 
 namespace DoctrineExtensions\Tests\Query;
 
-use Doctrine\Common\Cache\ArrayCache;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 class DbTestCase extends TestCase
 {
@@ -18,8 +18,8 @@ class DbTestCase extends TestCase
     public function setUp(): void
     {
         $this->configuration = new Configuration();
-        $this->configuration->setMetadataCacheImpl(new ArrayCache());
-        $this->configuration->setQueryCacheImpl(new ArrayCache());
+        $this->configuration->setMetadataCache(new ArrayAdapter());
+        $this->configuration->setQueryCache(new ArrayAdapter());
         $this->configuration->setProxyDir(__DIR__ . '/Proxies');
         $this->configuration->setProxyNamespace('DoctrineExtensions\Tests\Proxies');
         $this->configuration->setAutoGenerateProxyClasses(true);

--- a/tests/Types/CarbonDateTest.php
+++ b/tests/Types/CarbonDateTest.php
@@ -4,7 +4,6 @@ namespace DoctrineExtensions\Tests\Types;
 
 use Carbon\Carbon;
 use Carbon\CarbonImmutable;
-use Doctrine\Common\Cache\ArrayCache;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Configuration;
@@ -12,6 +11,7 @@ use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Tools\SchemaTool;
 use DoctrineExtensions\Tests\Entities\CarbonDate as Entity;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 use function assert;
 
@@ -39,8 +39,8 @@ class CarbonDateTest extends TestCase
     public function setUp(): void
     {
         $config = new Configuration();
-        $config->setMetadataCacheImpl(new ArrayCache());
-        $config->setQueryCacheImpl(new ArrayCache());
+        $config->setMetadataCache(new ArrayAdapter());
+        $config->setQueryCache(new ArrayAdapter());
         $config->setProxyDir(__DIR__ . '/Proxies');
         $config->setProxyNamespace('DoctrineExtensions\Tests\PHPUnit\Proxies');
         $config->setAutoGenerateProxyClasses(true);

--- a/tests/Types/ZendDateTest.php
+++ b/tests/Types/ZendDateTest.php
@@ -2,7 +2,6 @@
 
 namespace DoctrineExtensions\Tests\Types;
 
-use Doctrine\Common\Cache\ArrayCache;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Configuration;
@@ -10,6 +9,7 @@ use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Tools\SchemaTool;
 use DoctrineExtensions\Tests\Entities\ZendDate;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Zend_Date;
 
 use function assert;
@@ -34,8 +34,8 @@ class ZendDateTest extends TestCase
     public function setUp(): void
     {
         $config = new Configuration();
-        $config->setMetadataCacheImpl(new ArrayCache());
-        $config->setQueryCacheImpl(new ArrayCache());
+        $config->setMetadataCache(new ArrayAdapter());
+        $config->setQueryCache(new ArrayAdapter());
         $config->setProxyDir(__DIR__ . '/Proxies');
         $config->setProxyNamespace('DoctrineExtensions\Tests\PHPUnit\Proxies');
         $config->setAutoGenerateProxyClasses(true);


### PR DESCRIPTION
Doctrine Cache is dead and PSR-6 is the proper replacement. I'm using Symfony's implementation for the test suite.