### PR TITLE
Add doctrine/annotations to dev deps

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         "doctrine/orm": "^2.15"
     },
     "require-dev": {
+        "doctrine/annotations": "^1.14",
         "doctrine/cache": "^1.11",
         "doctrine/coding-standard": "^9.0.2 || ^12.0",
         "nesbot/carbon": "*",


### PR DESCRIPTION
This should fix our CI.

`doctrine/annotations` is not a mandatory dependency of the ORM anymore, yet our tests depend on it. Note that our tests are not yet compatible with v2 of the annotations library which is why I'm pinning to v1 for the moment.