### PR TITLE
Use ramsey/composer-install

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,14 +28,6 @@ jobs:
 
       - run: composer validate
 
-      - id: composer-cache
-        uses: actions/cache@v4
-        with:
-          path: vendor
-          key: php-${{ matrix.php }}-${{ hashFiles('**/composer.lock') }}
-          restore-keys: php-${{ matrix.php }}-
-
-      - if: steps.composer-cache.outputs.cache-hit != 'true'
-        run: composer install --prefer-dist --no-progress --no-suggest
+      - uses: "ramsey/composer-install@v2"
 
       - run: composer run test


### PR DESCRIPTION
The cache we use in our CI for composer dependencies is broken: It generates a hash based on the composer lock file which we don't commit and restores based on the PHP version which leaves us with a stale cache whenever we change the composer.json.

I'd like to delegate installing dependencies to the `ramsey/composer-install` action instead.