### PR TITLE
Add TestCase parent to Atan2Test class

### DIFF
--- a/tests/Query/Mysql/Atan2Test.php
+++ b/tests/Query/Mysql/Atan2Test.php
@@ -2,13 +2,15 @@
 
 namespace DoctrineExtensions\Tests\Query\Mysql;
 
-class Atan2Test
+use DoctrineExtensions\Tests\Query\MysqlTestCase;
+
+class Atan2Test extends MysqlTestCase
 {
     public function testAtan2(): void
     {
         $this->assertDqlProducesSql(
-            'SELECT ATAN2(2) from DoctrineExtensions\Tests\Entities\Blank b',
-            'SELECT ATAN2(2) AS sclr_0 FROM Blank b0_'
+            'SELECT ATAN2(2, 1) from DoctrineExtensions\Tests\Entities\Blank b',
+            'SELECT ATAN2(2, 1) AS sclr_0 FROM Blank b0_'
         );
     }
 }


### PR DESCRIPTION
There was a missing parent at Atan2Test. The atan2 function expects two parameters, so probably the test was not valid.