### PR TITLE
Drop old phpunit and symfony versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
         "nesbot/carbon": "*",
         "phpunit/phpunit": "^8.5 || ^9.0",
         "squizlabs/php_codesniffer": "^3.8",
-        "symfony/cache": "^4.4 || ^5.4 || ^6.4 || ^7.0",
-        "symfony/yaml": "^4.4 || ^5.3 || ^6.0 || ^7.0",
+        "symfony/cache": "^5.4 || ^6.4 || ^7.0",
+        "symfony/yaml": "^5.4 || ^6.0 || ^7.0",
         "zf1/zend-date": "^1.12",
         "zf1/zend-registry": "^1.12"
     },

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "doctrine/annotations": "^1.14 || ^2",
         "doctrine/coding-standard": "^9.0.2 || ^12.0",
         "nesbot/carbon": "*",
-        "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0",
+        "phpunit/phpunit": "^8.5 || ^9.0",
         "squizlabs/php_codesniffer": "^3.8",
         "symfony/cache": "^4.4 || ^5.4 || ^6.4 || ^7.0",
         "symfony/yaml": "^4.4 || ^5.3 || ^6.0 || ^7.0",

--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,10 @@
         "doctrine/annotations": "^1.14 || ^2",
         "doctrine/coding-standard": "^9.0.2 || ^12.0",
         "nesbot/carbon": "*",
-        "phpunit/phpunit": "^8.5 || ^9.0",
+        "phpunit/phpunit": "^8.5 || ^9.6",
         "squizlabs/php_codesniffer": "^3.8",
         "symfony/cache": "^5.4 || ^6.4 || ^7.0",
-        "symfony/yaml": "^5.4 || ^6.0 || ^7.0",
+        "symfony/yaml": "^5.4 || ^6.4 || ^7.0",
         "zf1/zend-date": "^1.12",
         "zf1/zend-registry": "^1.12"
     },


### PR DESCRIPTION
If I understand correctly, orm2 tests will run with `dependency-versions: "lowest"` setting and orm3 tests will run with `highest` setting. Due to the restriction of orm3 php>=8.1, orm2 tests must also run on php8.0. The phpunit 7 does not support php8, so we should drop phpunit7.

And I dropped symfony 4 because that branch is no longer officially supported.

What do you think?