### PR TITLE
Made Carbon types compatible with DBAL 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require-dev": {
         "doctrine/annotations": "^1.14 || ^2",
         "doctrine/coding-standard": "^9.0.2 || ^12.0",
-        "nesbot/carbon": "*",
+        "nesbot/carbon": "^2.72 || ^3",
         "phpunit/phpunit": "^8.5 || ^9.6",
         "squizlabs/php_codesniffer": "^3.8",
         "symfony/cache": "^5.4 || ^6.4 || ^7.0",

--- a/src/Types/CarbonDateTimeType.php
+++ b/src/Types/CarbonDateTimeType.php
@@ -2,14 +2,12 @@
 
 namespace DoctrineExtensions\Types;
 
-use Carbon\Carbon;
-use DateTime;
-use DateTimeInterface;
-use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\DateTimeType;
 
 class CarbonDateTimeType extends DateTimeType
 {
+    use CarbonTypeImplementation;
+
     public const CARBONDATETIME = 'carbondatetime';
 
     /**
@@ -18,29 +16,5 @@ class CarbonDateTimeType extends DateTimeType
     public function getName()
     {
         return self::CARBONDATETIME;
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @return Carbon|DateTimeInterface
-     */
-    public function convertToPHPValue($value, AbstractPlatform $platform)
-    {
-        $result = parent::convertToPHPValue($value, $platform);
-
-        if ($result instanceof DateTime) {
-            return Carbon::instance($result);
-        }
-
-        return $result;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function requiresSQLCommentHint(AbstractPlatform $platform)
-    {
-        return true;
     }
 }

--- a/src/Types/CarbonDateTimeTzType.php
+++ b/src/Types/CarbonDateTimeTzType.php
@@ -2,14 +2,12 @@
 
 namespace DoctrineExtensions\Types;
 
-use Carbon\Carbon;
-use DateTime;
-use DateTimeInterface;
-use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\DateTimeTzType;
 
 class CarbonDateTimeTzType extends DateTimeTzType
 {
+    use CarbonTypeImplementation;
+
     public const CARBONDATETIMETZ = 'carbondatetimetz';
 
     /**
@@ -18,29 +16,5 @@ class CarbonDateTimeTzType extends DateTimeTzType
     public function getName()
     {
         return self::CARBONDATETIMETZ;
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @return Carbon|DateTimeInterface
-     */
-    public function convertToPHPValue($value, AbstractPlatform $platform)
-    {
-        $result = parent::convertToPHPValue($value, $platform);
-
-        if ($result instanceof DateTime) {
-            return Carbon::instance($result);
-        }
-
-        return $result;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function requiresSQLCommentHint(AbstractPlatform $platform)
-    {
-        return true;
     }
 }

--- a/src/Types/CarbonDateType.php
+++ b/src/Types/CarbonDateType.php
@@ -2,14 +2,12 @@
 
 namespace DoctrineExtensions\Types;
 
-use Carbon\Carbon;
-use DateTime;
-use DateTimeInterface;
-use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\DateType;
 
 class CarbonDateType extends DateType
 {
+    use CarbonTypeImplementation;
+
     public const CARBONDATE = 'carbondate';
 
     /**
@@ -18,29 +16,5 @@ class CarbonDateType extends DateType
     public function getName()
     {
         return self::CARBONDATE;
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @return Carbon|DateTimeInterface
-     */
-    public function convertToPHPValue($value, AbstractPlatform $platform)
-    {
-        $result = parent::convertToPHPValue($value, $platform);
-
-        if ($result instanceof DateTime) {
-            return Carbon::instance($result);
-        }
-
-        return $result;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function requiresSQLCommentHint(AbstractPlatform $platform)
-    {
-        return true;
     }
 }

--- a/src/Types/CarbonImmutableDateTimeType.php
+++ b/src/Types/CarbonImmutableDateTimeType.php
@@ -2,14 +2,12 @@
 
 namespace DoctrineExtensions\Types;
 
-use Carbon\CarbonImmutable;
-use DateTime;
-use DateTimeInterface;
-use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Types\DateTimeType;
+use Carbon\Doctrine\DateTimeImmutableType;
 
-class CarbonImmutableDateTimeType extends DateTimeType
+class CarbonImmutableDateTimeType extends DateTimeImmutableType
 {
+    use CarbonImmutableTypeImplementation;
+
     public const CARBONDATETIME = 'carbondatetime_immutable';
 
     /**
@@ -18,29 +16,5 @@ class CarbonImmutableDateTimeType extends DateTimeType
     public function getName()
     {
         return self::CARBONDATETIME;
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @return CarbonImmutable|DateTimeInterface
-     */
-    public function convertToPHPValue($value, AbstractPlatform $platform)
-    {
-        $result = parent::convertToPHPValue($value, $platform);
-
-        if ($result instanceof DateTime) {
-            return CarbonImmutable::instance($result);
-        }
-
-        return $result;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function requiresSQLCommentHint(AbstractPlatform $platform)
-    {
-        return true;
     }
 }

--- a/src/Types/CarbonImmutableDateTimeTzType.php
+++ b/src/Types/CarbonImmutableDateTimeTzType.php
@@ -2,14 +2,12 @@
 
 namespace DoctrineExtensions\Types;
 
-use Carbon\CarbonImmutable;
-use DateTime;
-use DateTimeInterface;
-use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Types\DateTimeTzType;
+use Doctrine\DBAL\Types\DateTimeTzImmutableType;
 
-class CarbonImmutableDateTimeTzType extends DateTimeTzType
+class CarbonImmutableDateTimeTzType extends DateTimeTzImmutableType
 {
+    use CarbonImmutableTypeImplementation;
+
     public const CARBONDATETIMETZ = 'carbondatetimetz_immutable';
 
     /**
@@ -18,29 +16,5 @@ class CarbonImmutableDateTimeTzType extends DateTimeTzType
     public function getName()
     {
         return self::CARBONDATETIMETZ;
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @return CarbonImmutable|DateTimeInterface
-     */
-    public function convertToPHPValue($value, AbstractPlatform $platform)
-    {
-        $result = parent::convertToPHPValue($value, $platform);
-
-        if ($result instanceof DateTime) {
-            return CarbonImmutable::instance($result);
-        }
-
-        return $result;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function requiresSQLCommentHint(AbstractPlatform $platform)
-    {
-        return true;
     }
 }

--- a/src/Types/CarbonImmutableDateType.php
+++ b/src/Types/CarbonImmutableDateType.php
@@ -2,14 +2,12 @@
 
 namespace DoctrineExtensions\Types;
 
-use Carbon\CarbonImmutable;
-use DateTime;
-use DateTimeInterface;
-use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Types\DateType;
+use Doctrine\DBAL\Types\DateImmutableType;
 
-class CarbonImmutableDateType extends DateType
+class CarbonImmutableDateType extends DateImmutableType
 {
+    use CarbonImmutableTypeImplementation;
+
     public const CARBONDATE = 'carbondate_immutable';
 
     /**
@@ -18,29 +16,5 @@ class CarbonImmutableDateType extends DateType
     public function getName()
     {
         return self::CARBONDATE;
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @return CarbonImmutable|DateTimeInterface
-     */
-    public function convertToPHPValue($value, AbstractPlatform $platform)
-    {
-        $result = parent::convertToPHPValue($value, $platform);
-
-        if ($result instanceof DateTime) {
-            return CarbonImmutable::instance($result);
-        }
-
-        return $result;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function requiresSQLCommentHint(AbstractPlatform $platform)
-    {
-        return true;
     }
 }

--- a/src/Types/CarbonImmutableTimeType.php
+++ b/src/Types/CarbonImmutableTimeType.php
@@ -2,14 +2,12 @@
 
 namespace DoctrineExtensions\Types;
 
-use Carbon\CarbonImmutable;
-use DateTime;
-use DateTimeInterface;
-use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Types\TimeType;
+use Doctrine\DBAL\Types\TimeImmutableType;
 
-class CarbonImmutableTimeType extends TimeType
+class CarbonImmutableTimeType extends TimeImmutableType
 {
+    use CarbonImmutableTypeImplementation;
+
     public const CARBONTIME = 'carbontime_immutable';
 
     /**
@@ -18,29 +16,5 @@ class CarbonImmutableTimeType extends TimeType
     public function getName()
     {
         return self::CARBONTIME;
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @return CarbonImmutable|DateTimeInterface
-     */
-    public function convertToPHPValue($value, AbstractPlatform $platform)
-    {
-        $result = parent::convertToPHPValue($value, $platform);
-
-        if ($result instanceof DateTime) {
-            return CarbonImmutable::instance($result);
-        }
-
-        return $result;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function requiresSQLCommentHint(AbstractPlatform $platform)
-    {
-        return true;
     }
 }

--- a/src/Types/CarbonImmutableTypeImplementation.php
+++ b/src/Types/CarbonImmutableTypeImplementation.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineExtensions\Types;
+
+use Carbon\Carbon;
+use Carbon\CarbonImmutable;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+
+/** @internal */
+trait CarbonImmutableTypeImplementation
+{
+    public function convertToDatabaseValue($value, AbstractPlatform $platform): ?string
+    {
+        if ($value instanceof Carbon) {
+            $value = CarbonImmutable::instance($value);
+        }
+
+        return parent::convertToDatabaseValue($value, $platform);
+    }
+
+    public function convertToPHPValue($value, AbstractPlatform $platform): ?CarbonImmutable
+    {
+        $result = parent::convertToPHPValue($value, $platform);
+        if ($result === null) {
+            return null;
+        }
+
+        return CarbonImmutable::instance($result);
+    }
+
+    public function requiresSQLCommentHint(AbstractPlatform $platform): bool
+    {
+        return true;
+    }
+}

--- a/src/Types/CarbonTimeType.php
+++ b/src/Types/CarbonTimeType.php
@@ -2,14 +2,12 @@
 
 namespace DoctrineExtensions\Types;
 
-use Carbon\Carbon;
-use DateTime;
-use DateTimeInterface;
-use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\TimeType;
 
 class CarbonTimeType extends TimeType
 {
+    use CarbonTypeImplementation;
+
     public const CARBONTIME = 'carbontime';
 
     /**
@@ -18,29 +16,5 @@ class CarbonTimeType extends TimeType
     public function getName()
     {
         return self::CARBONTIME;
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @return Carbon|DateTimeInterface
-     */
-    public function convertToPHPValue($value, AbstractPlatform $platform)
-    {
-        $result = parent::convertToPHPValue($value, $platform);
-
-        if ($result instanceof DateTime) {
-            return Carbon::instance($result);
-        }
-
-        return $result;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function requiresSQLCommentHint(AbstractPlatform $platform)
-    {
-        return true;
     }
 }

--- a/src/Types/CarbonTypeImplementation.php
+++ b/src/Types/CarbonTypeImplementation.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineExtensions\Types;
+
+use Carbon\Carbon;
+use Carbon\CarbonImmutable;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+
+/** @internal */
+trait CarbonTypeImplementation
+{
+    public function convertToDatabaseValue($value, AbstractPlatform $platform): ?string
+    {
+        if ($value instanceof CarbonImmutable) {
+            $value = Carbon::instance($value);
+        }
+
+        return parent::convertToDatabaseValue($value, $platform);
+    }
+
+    public function convertToPHPValue($value, AbstractPlatform $platform): ?Carbon
+    {
+        $result = parent::convertToPHPValue($value, $platform);
+        if ($result === null) {
+            return null;
+        }
+
+        return Carbon::instance($result);
+    }
+
+    public function requiresSQLCommentHint(AbstractPlatform $platform): bool
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
This PR changes the class hierarchy and return types of the Carbon type classes in order to make them compatible with DBAL 4.

This might be seen as a breaking change if those classes are used in a creative way. However, I assume that those types are not used to pass `instanceof` checks or extended in any way.

We could also consider bumping to version 2.0 to account for these breaking changes.