### PR TITLE
Add test for Mysql/Extract

### DIFF
--- a/tests/Query/Mysql/ExtractTest.php
+++ b/tests/Query/Mysql/ExtractTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace DoctrineExtensions\Tests\Query\Mysql;
+
+use DoctrineExtensions\Tests\Query\MysqlTestCase;
+
+class ExtractTest extends MysqlTestCase
+{
+    public function testExtract(): void
+    {
+        $this->assertDqlProducesSql(
+            'SELECT EXTRACT(MINUTE WITH 2) from DoctrineExtensions\Tests\Entities\Blank b',
+            'SELECT EXTRACT(MINUTE FROM 2) AS sclr_0 FROM Blank b0_'
+        );
+
+        $this->assertDqlProducesSql(
+            'SELECT EXTRACT(MINUTE AS 2) from DoctrineExtensions\Tests\Entities\Blank b',
+            'SELECT EXTRACT(MINUTE FROM 2) AS sclr_0 FROM Blank b0_'
+        );
+
+        $this->assertDqlProducesSql(
+            'SELECT EXTRACT(MINUTE FROM 2) from DoctrineExtensions\Tests\Entities\Blank b',
+            'SELECT EXTRACT(MINUTE FROM 2) AS sclr_0 FROM Blank b0_'
+        );
+
+        $this->assertDqlProducesSql(
+            'SELECT EXTRACT(MINUTE JOIN 2) from DoctrineExtensions\Tests\Entities\Blank b',
+            'SELECT EXTRACT(MINUTE FROM 2) AS sclr_0 FROM Blank b0_'
+        );
+    }
+}


### PR DESCRIPTION
The test points to a parser implementation problem.
1) leave it as it is and use the test to indicate that it's not really OK
2) BC break and restrict to FORM?