### PR TITLE
Fix deprecation

### DIFF
--- a/src/Types/CarbonDateType.php
+++ b/src/Types/CarbonDateType.php
@@ -10,10 +10,7 @@ class CarbonDateType extends DateType
 
     public const CARBONDATE = 'carbondate';
 
-    /**
-     * {@inheritDoc}
-     */
-    public function getName()
+    public function getName(): string
     {
         return self::CARBONDATE;
     }


### PR DESCRIPTION
This small fix the following deprecation notice:

```
[2025-01-15T22:40:38.930794+00:00] deprecation.INFO: User Deprecated: Method "Doctrine\DBAL\Types\Type::getName()" might add "string" as a native return type declaration in the future. Do the same in child class "DoctrineExtensions\Types\CarbonDateType" now to avoid errors or add an explicit @return annotation to suppress this message. {"exception":"[object] (ErrorException(code: 0): User Deprecated: Method \"Doctrine\\DBAL\\Types\\Type::getName()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"DoctrineExtensions\\Types\\CarbonDateType\" now to avoid errors or add an explicit @return annotation to suppress this message. At vendor/symfony/error-handler/DebugClassLoader.php:341)"} []
```

(found with symfony 7.2, this not happens in 7.1)